### PR TITLE
Add 'npm run lint' to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ node_js:
   - node
   - lts/*
 
-script: npm run build
+script:
+  - npm run lint
+  - npm run build


### PR DESCRIPTION
CI by its definition is intended to ensure that there's no regression in
the code, both functional and stylistic.