### PR TITLE
Set production options for css-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,19 @@ module.exports = () => {
           use: ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
-              { loader: 'css-loader', options: { modules: true } },
+              {
+                loader: 'css-loader',
+                options: {
+                  modules: true,
+                  minimize: isProduction,
+
+                  // Enable source maps if they are specified in devtool
+                  // option. God-Knows-Why css-loader doesn't check devtool
+                  // value in order to initialize its sourceMap value, hence
+                  // this line.
+                  sourceMap: true,
+                },
+              },
               { loader: 'stylus-loader' },
             ],
           }),


### PR DESCRIPTION
There are two things in this patch. First, we start producing CSS source
maps and this is very important, because we use CSS modules which mangle
CSS rules, i.e. change their names making unreal to map CSS classed back
to sources. Second, we minimize produced CSS for production builds
decreasing size-to-fetch for browsers.