### PR TITLE
 Change Link component to NavLink

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 
 const Header = () => (
   <header>
     <nav>
       <ul>
-        <li><Link to="/">New snippet</Link></li>
-        <li><Link to="/recent">Recent snippets</Link></li>
-        <li><Link to="/upload">Upload snippet</Link></li>
-        <li><Link to="/about">About</Link></li>
-        <li><Link to="/sign-in">Sign in</Link></li>
+        <li><NavLink to="/" activeClassName="active">New snippet</NavLink></li>
+        <li><NavLink to="/recent" activeClassName="active">Recent snippets</NavLink></li>
+        <li><NavLink to="/upload" activeClassName="active">Upload snippet</NavLink></li>
+        <li><NavLink to="/about" activeClassName="active">About</NavLink></li>
+        <li><NavLink to="/sign-in" activeClassName="active">Sign in</NavLink></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
best to be merged after #3 

NavLink component is better than Link in the way that it sets CSS class
to active page. This will help us to show which page is active at the
moment.