### PR TITLE
Remove max-width for header content

### DIFF
--- a/src/styles/Header.styl
+++ b/src/styles/Header.styl
@@ -19,7 +19,6 @@
     justify-content: space-between
     align-items: center
     width: "calc(100% - %s)" % offset
-    max-width: 1024px
   &-logo
     width: offset
     height: offset


### PR DESCRIPTION
It was done to make header look natural on screens wider than 1024px
and to be aligned to main content