### PR TITLE
Add title attribute to all links on sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -7,17 +7,17 @@ const Sidebar = () => (
   <nav className="sidebar" key="navigation">
     <ul className="sidebar-list">
       <li className="sidebar-item">
-        <NavLink exact to="/" activeClassName="active">
+        <NavLink exact to="/" activeClassName="active" title="New Snippet">
           <i className="icon-new" />
         </NavLink>
       </li>
       <li className="sidebar-item sidebar-item-border">
-        <NavLink to="/recent" activeClassName="active">
+        <NavLink to="/recent" activeClassName="active" title="Recent Snippet">
           <i className="icon-recent" />
         </NavLink>
       </li>
       <li className="sidebar-item">
-        <NavLink to="/about" activeClassName="active">
+        <NavLink to="/about" activeClassName="active" title="About">
           <i className="icon-about" />
         </NavLink>
       </li>


### PR DESCRIPTION
This was done to improve accessibility by showing text on hover
over sidebar item, so user will be able to see where each link is headed