### PR TITLE
Use builtin uglifyjs-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -275,12 +275,6 @@
         "normalize-path": "2.1.1"
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -1486,27 +1480,6 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
-    "cacache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
-      "integrity": "sha1-PgX25hYRfZtUZlsbIMiuuT6l028=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.0.0",
-        "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
-      }
-    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -1637,12 +1610,6 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -1915,20 +1882,6 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
-    "copy-concurrently": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
-    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -2146,12 +2099,6 @@
       "requires": {
         "array-find-index": "1.0.2"
       }
-    },
-    "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-      "dev": true
     },
     "d": {
       "version": "1.0.0",
@@ -2398,18 +2345,6 @@
         "domelementtype": "1.3.0"
       }
     },
-    "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2470,15 +2405,6 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.19"
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -3269,16 +3195,6 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
-    "flush-write-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
-      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3312,33 +3228,11 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
       "dev": true
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4820,12 +4714,6 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
-    },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
@@ -5745,24 +5633,6 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
-    "mississippi": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
-        "flush-write-stream": "1.0.2",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "1.0.3",
-        "pumpify": "1.3.5",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
-      }
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -5770,20 +5640,6 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      }
-    },
-    "move-concurrently": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
       }
     },
     "ms": {
@@ -6142,17 +5998,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
       "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
       "dev": true
-    },
-    "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-      "dev": true,
-      "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
     },
     "param-case": {
       "version": "2.1.1",
@@ -6958,12 +6803,6 @@
         "asap": "2.0.6"
       }
     },
-    "promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "dev": true
-    },
     "prop-types": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
@@ -7007,27 +6846,6 @@
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
         "randombytes": "2.0.5"
-      }
-    },
-    "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
-      }
-    },
-    "pumpify": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-      "dev": true,
-      "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.3",
-        "pump": "1.0.3"
       }
     },
     "punycode": {
@@ -7560,15 +7378,6 @@
         "is-promise": "2.1.0"
       }
     },
-    "run-queue": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0"
-      }
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -7646,12 +7455,6 @@
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
       }
-    },
-    "serialize-javascript": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
-      "dev": true
     },
     "serve-index": {
       "version": "1.9.1",
@@ -7870,15 +7673,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "ssri": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
-      "integrity": "sha1-E8GTkLYGyCHyoQ0Cs1HBcpuU2M8=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -7895,16 +7689,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "stream-each": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha1-joxGP5HaiZF3h2WHP+TZYNj2Fr0=",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "stream-shift": "1.0.0"
-      }
-    },
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -7917,12 +7701,6 @@
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -8152,16 +7930,6 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      }
-    },
     "thunky": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
@@ -8304,40 +8072,6 @@
       "dev": true,
       "optional": true
     },
-    "uglifyjs-webpack-plugin": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.4.tgz",
-      "integrity": "sha1-5DrW5zbDFQJOuZSBp8yTYtagZr4=",
-      "dev": true,
-      "requires": {
-        "cacache": "10.0.1",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.3.0",
-        "serialize-javascript": "1.4.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.1",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.5.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        },
-        "uglify-es": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.1.tgz",
-          "integrity": "sha1-dVayCNOshYToGitw//Qkq7zX48w=",
-          "dev": true,
-          "requires": {
-            "commander": "2.12.2",
-            "source-map": "0.6.1"
-          }
-        }
-      }
-    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -8358,24 +8092,6 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
-    },
-    "unique-filename": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-      "dev": true,
-      "requires": {
-        "unique-slug": "2.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "0.1.4"
-      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -8990,16 +8706,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
-    },
-    "worker-farm": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
-      "integrity": "sha1-MrMS5dw9XUXXnvRKzCWHSRzXKa4=",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.6",
-        "xtend": "4.0.1"
-      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "style-loader": "^0.19.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
-    "uglifyjs-webpack-plugin": "^1.0.1",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.3",
     "webpack-merge": "^4.1.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const merge = require('webpack-merge');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 
 module.exports = () => {
@@ -131,7 +130,7 @@ module.exports = () => {
         // Enable source maps if they are specified in devtool option. By some
         // funny reason UglifyJSPlugin does not check devtool option and won't
         // produce them unless its sourceMap option set to true.
-        new UglifyJSPlugin({ sourceMap: true }),
+        new webpack.optimize.UglifyJsPlugin({ sourceMap: true }),
       ],
     });
   }


### PR DESCRIPTION
So far XSnippet Web depends on uglify-webpack-plugin v1.0.1 that depends
on uglify-es v3.1.3 but since the latter is added to dependencies with ^
mark it means we can use any minor version (i.e. any 3.x).

Unfortunately, uglify-es 3.3.0+ (released 2 days ago) broke something
and any minified build currently produced doesn't work and fail with JS
errors in browser console. One way to fix it is to try to pin uglify-es
to latest working version which is v3.2.2. Another is to use builtin
uglify-webpack-plugin which is old (v0.4.2).

This commit implements the latter approach and use builtin version
instead. The rationale is simple: there's no need to use latest version
and we are more than happy with tested bundled version. :)