### PR TITLE
Use exact routes to pages

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,10 +13,10 @@ const Main = () => (
   <main className="main">
     <Switch>
       <Route exact path="/" component={NewSnippet} />
-      <Route path="/recent" component={RecentSnippets} />
-      <Route path="/about" component={About} />
-      <Route path="/sign-in" component={SignIn} />
-      <Route path="/:id" component={Snippet} />
+      <Route exact path="/recent" component={RecentSnippets} />
+      <Route exact path="/about" component={About} />
+      <Route exact path="/sign-in" component={SignIn} />
+      <Route exact path="/:id(\d+)" component={Snippet} />
     </Switch>
   </main>
 );


### PR DESCRIPTION
By default, react route matches a URI (let's say) greedy which means the
following route:

    <Route path="/about" ... />

will match the following URIs:

    /about
    /about/
    /about/foo
    /about/foo/bar

Well, that's not what would we expect. That's why we want to set 'exact'
option on routes, so only two cases would be allows for the example
above:

    /about
    /about/

Any other options will end up with 404 Not Found.