### PR TITLE
Title fix for RecentSnippetItem and Snippet

### DIFF
--- a/src/components/RecentSnippetItem.jsx
+++ b/src/components/RecentSnippetItem.jsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const RecentSnippetItem = ({ snippet }) => (
-  <li className="recent-snippet-item">
-    <div className="recent-snippet-data">
-      <div>
-        <span className="recent-snippet-data-title">{snippet.get('title')}</span>
-        <span className="recent-snippet-data-lang">[ {snippet.get('syntax', 'Text')} ]</span>
+const RecentSnippetItem = ({ snippet }) => {
+  const snippetTitle = snippet.get('title') || `#${snippet.get('id')}, Untitled`;
+
+  return (
+    <li className="recent-snippet-item">
+      <div className="recent-snippet-data">
+        <div>
+          <span className="recent-snippet-data-title">{snippetTitle}</span>
+          <span className="recent-snippet-data-lang">[ {snippet.get('syntax', 'Text')} ]</span>
+        </div>
+        <span className="recent-snippet-data-author">By Guest</span>
       </div>
-      <span className="recent-snippet-data-author">By Guest</span>
-    </div>
-    <div>
-      <button className="recent-snippet-button light">Raw</button>
-      <button className="recent-snippet-button light">Download</button>
-      <Link to={`${snippet.get('id')}`} className="recent-snippet-button">Show</Link>
-    </div>
-  </li>
-);
+      <div>
+        <button className="recent-snippet-button light">Raw</button>
+        <button className="recent-snippet-button light">Download</button>
+        <Link to={`${snippet.get('id')}`} className="recent-snippet-button">Show</Link>
+      </div>
+    </li>
+  );
+};
 
 export default RecentSnippetItem;

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -34,7 +34,7 @@ class Snippet extends React.Component {
 
     if (!snippet) return <Spinner />;
 
-    const snippetTitle = snippet.get('title') ? snippet.get('title') : `#${snippet.get('id')}, Untitled`;
+    const snippetTitle = snippet.get('title') || `#${snippet.get('id')}, Untitled`;
 
     return (
       [


### PR DESCRIPTION
To keep consistent title and to follow existing behaviour. So
now if title is undefined Its id and Undefined word will appear