### PR TITLE
Add redirect to newly added snippet

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -31,7 +31,7 @@ export const fetchSyntaxes = dispatch => (
     .then(json => dispatch(setSyntaxes(json)))
 );
 
-export const postSnippet = snippet => dispatch => (
+export const postSnippet = (snippet, onSuccess) => dispatch => (
   fetch('http://api.xsnippet.org/snippets', {
     method: 'POST',
     headers: {
@@ -41,5 +41,8 @@ export const postSnippet = snippet => dispatch => (
     body: JSON.stringify(snippet),
   })
     .then(response => response.json())
-    .then(json => dispatch(setSnippet(json)))
+    .then((json) => {
+      dispatch(setSnippet(json));
+      onSuccess(json);
+    })
 );

--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -42,8 +42,8 @@ class NewSnippet extends React.Component {
 
   postSnippet(e) {
     e.preventDefault();
-    const { dispatch } = this.props;
-    dispatch(actions.postSnippet(this.state));
+    const { dispatch, history } = this.props;
+    dispatch(actions.postSnippet(this.state, json => history.push(`/${json.id}`)));
   }
 
   render() {


### PR DESCRIPTION
Since we don't have notification about successfully added snippet
it was a best choise to redirect to snippet details after submitting.
To redirect we need to have id of new snippet which is generates on
backend side, thus we need to call redirect after new snippet is
created. We reach this just to pass callback to action.