### PR TITLE
Style fixes for code mirror areas

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Quicksand:300,400|Raleway:600|Ubuntu+Mono" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Quicksand:300,400|Raleway:600" rel="stylesheet">
     <title>XSnippet</title>
   </head>
   <body>

--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -3,7 +3,7 @@
 .react-codemirror2,
 .CodeMirror
   height: 100% !important
-  font-family: font-ubuntu-mono !important
+  line-height: 1.2
 
 .new-snippet .react-codemirror2,
 .new-snippet .CodeMirror
@@ -15,6 +15,7 @@
 
 .CodeMirror-sizer
   margin-left: 39px
+  padding-top: 5px
 
 .CodeMirror-gutters
   border-right: none

--- a/src/styles/common/variables.styl
+++ b/src/styles/common/variables.styl
@@ -37,4 +37,3 @@ offset = 70px
 
 font-raleway = 'Raleway', sans-serif
 font-quicksand = 'Quicksand', sans-serif
-font-ubuntu-mono = 'Ubuntu Mono', monospace


### PR DESCRIPTION
Added padding top to divide header from code mirror area so now
it doesn't seem to close also removed custom font from code mirror
areas