### PR TITLE
Use createStore() factory instead of singleton

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,7 +4,9 @@ import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 
 import App from './components/App';
-import store from './store';
+import createStore from './store';
+
+const store = createStore();
 
 ReactDOM.render(
   (

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,9 +3,13 @@ import thunk from 'redux-thunk';
 
 import reducer from '../reducers';
 
-// Redux Thunk middleware allows you to write action creators that return a
-// function instead of an action. The thunk can be used to delay the dispatch
-// of an action, or to dispatch only if a certain condition is met. The former
-// is the case for XSnippet Web since we need to fetch data via HTTP API first
-// and then dispatch it to store.
-export default redux.createStore(reducer, redux.applyMiddleware(thunk));
+function createStore() {
+  // Redux Thunk middleware allows you to write action creators that return a
+  // function instead of an action. The thunk can be used to delay the dispatch
+  // of an action, or to dispatch only if a certain condition is met. The
+  // former is the case for XSnippet Web since we need to fetch data via HTTP
+  // API first and then dispatch it to store.
+  return redux.createStore(reducer, redux.applyMiddleware(thunk));
+}
+
+export default createStore;


### PR DESCRIPTION
The need for a factory function comes from our desire to use not-mocked
production-like store in tests. Since each test may change store in
unpredicted way, we will want to create a store instance for each test
independently, hence this factory function. Otherwise, having globally
available singleton instance may introduce unpredicted test failures.