### PR TITLE
Use immutable.Map() as initial state for store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8840,6 +8840,11 @@
         "symbol-observable": "1.1.0"
       }
     },
+    "redux-immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-4.0.0.tgz",
+      "integrity": "sha1-Ohoy32Y2ZGK2NpHw4dw15HK7yfM="
+    },
     "redux-thunk": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
+    "redux-immutable": "^4.0.0",
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {

--- a/src/components/RecentSnippets.jsx
+++ b/src/components/RecentSnippets.jsx
@@ -26,6 +26,6 @@ class RecentSnippets extends React.Component {
 }
 
 export default connect(state => ({
-  snippets: state.snippets,
-  recent: state.recent,
+  snippets: state.get('snippets'),
+  recent: state.get('recent'),
 }))(RecentSnippets);

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -83,5 +83,5 @@ class Snippet extends React.Component {
 }
 
 export default connect((state, ownProps) => ({
-  snippet: state.snippets.get(Number(ownProps.match.params.id)),
+  snippet: state.getIn(['snippets', Number(ownProps.match.params.id)]),
 }))(Snippet);

--- a/src/components/Syntaxes.jsx
+++ b/src/components/Syntaxes.jsx
@@ -57,5 +57,5 @@ class Syntaxes extends React.Component {
 }
 
 export default connect(state => ({
-  syntaxes: state.syntaxes,
+  syntaxes: state.get('syntaxes'),
 }))(Syntaxes);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,5 @@
 import { List, Map, fromJS } from 'immutable';
-import { combineReducers } from 'redux';
+import { combineReducers } from 'redux-immutable';
 
 const snippets = (state = Map(), action) => {
   switch (action.type) {


### PR DESCRIPTION
We already use immutable.js classes in state to be protected from
accidental state mutation. However, the protect is not complete as the
root object is still plain Object() instance. So let's complete
protection by using immutable.js Map as root object for state.

Besides, having root state as immutable.js Map we make it easier to
convert the whole state to plain JS in tests.