### PR TITLE
Fix ability to copy-paste code from snippet page

### DIFF
--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -69,7 +69,7 @@ class Snippet extends React.Component {
           <div className="snippet-code">
             <CodeMirror
               value={`${snippet.get('content')}`}
-              options={{ lineNumbers: true, readOnly: 'nocursor', mode: modeInfo.mime }}
+              options={{ lineNumbers: true, readOnly: true, mode: modeInfo.mime }}
             />
             <div className="snippet-code-bottom-bar">
               <button className="snippet-button light">Raw</button>

--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -22,3 +22,7 @@
 
 .snippet .CodeMirror-line
   padding-left: 20px !important
+
+.snippet .CodeMirror-cursor {
+  display: none !important
+}


### PR DESCRIPTION
In case of CodeMirror has readOnly 'nocursor' option the text cannot
be copied because CodeMirror loose its focus. That basically menas we
can't use this option and we need to use some sort of workaround. One
way to solve this is by using readOnly true option and hidding
the blinking cursor with css rule.