### PR TITLE
Style and UX fixes

### DIFF
--- a/src/components/RecentSnippetItem.jsx
+++ b/src/components/RecentSnippetItem.jsx
@@ -8,7 +8,7 @@ const RecentSnippetItem = ({ snippet }) => {
     <li className="recent-snippet-item">
       <div className="recent-snippet-data">
         <div>
-          <span className="recent-snippet-data-title">{snippetTitle}</span>
+          <Link to={`${snippet.get('id')}`} className="recent-snippet-data-title">{snippetTitle}</Link>
           <span className="recent-snippet-data-lang">[ {snippet.get('syntax', 'Text')} ]</span>
         </div>
         <span className="recent-snippet-data-author">By Guest</span>

--- a/src/styles/RecentSnippets.styl
+++ b/src/styles/RecentSnippets.styl
@@ -24,6 +24,9 @@
     &-title
       color: text-green
       font-size: 19px
+      text-decoration: none
+      &:hover
+        color: text-dark-green
     &-lang
       margin-left: 15px
       color: text-dark

--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -3,7 +3,7 @@
 .react-codemirror2,
 .CodeMirror
   height: 100% !important
-  line-height: 1.2
+  line-height: 1.4
 
 .new-snippet .react-codemirror2,
 .new-snippet .CodeMirror

--- a/src/styles/common/variables.styl
+++ b/src/styles/common/variables.styl
@@ -4,6 +4,7 @@ site-bg = color-gainboro-white-s0
 text-dark = color-night-rider-grey-s1
 text-light = color-white-white-s100
 text-green = color-niagara-green-s75
+text-dark-green = color-elf-green-green-s82
 text-grey = color-shady-lady-grey-s0
 
 border-light = color-white-smoke-white-s0


### PR DESCRIPTION
This commit contains changed line-height for codeMirror textarea,
so now it doesn't look squeezed. Changed title into Link on recent
snippets so user could click on it.