### PR TITLE
Linter: enforce quotes for JS object attributes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
       "specialLink": ["to"]
     }],
     "react/prop-types": [0],
-    "jsx-a11y/click-events-have-key-events": [0]
+    "jsx-a11y/click-events-have-key-events": [0],
+    "quote-props": ["error", "consistent"]
   },
   "plugins": ["jest"]
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -50,7 +50,7 @@ export const postSnippet = (snippet, onSuccess) => dispatch => (
   fetch('http://api.xsnippet.org/snippets', {
     method: 'POST',
     headers: {
-      Accept: 'application/json',
+      'Accept': 'application/json',
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(snippet),


### PR DESCRIPTION
So far we have weird ESLint setup as it requires to not use quotes for
plain attribute names, and enforce quotes for complex ones. Thus I've
changed eslint rule to consistent value, so this always should be
the same.

Closes: #47