### PR TITLE
Temporary disable sign in link on header

### DIFF
--- a/src/styles/Header.styl
+++ b/src/styles/Header.styl
@@ -40,6 +40,7 @@
     &-x
       color: text-green
   &-sign-in
+    pointer-events: none
     margin-right: 20px
     & a
       display: flex


### PR DESCRIPTION
So far we don't have any functionality for sign in and it might cause
some kind of misunderstanding. To avoid this this commit dissables
sing-in link.