### PR TITLE
Preserve communication protocol in requests to API

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -14,7 +14,7 @@ export const fetchRecentSnippets = marker => (dispatch) => {
   let qs = '';
   if (marker) { qs = `&marker=${marker}`; }
 
-  return fetch(`http://api.xsnippet.org/snippets?limit=20${qs}`)
+  return fetch(`//api.xsnippet.org/snippets?limit=20${qs}`)
     .then((response) => {
       const links = parseLinkHeader(response.headers.get('Link'));
 
@@ -30,7 +30,7 @@ export const setSnippet = snippet => ({
 });
 
 export const fetchSnippet = id => dispatch => (
-  fetch(`http://api.xsnippet.org/snippets/${id}`)
+  fetch(`//api.xsnippet.org/snippets/${id}`)
     .then(response => response.json())
     .then(json => dispatch(setSnippet(json)))
 );
@@ -41,13 +41,13 @@ export const setSyntaxes = syntaxes => ({
 });
 
 export const fetchSyntaxes = dispatch => (
-  fetch('http://api.xsnippet.org/syntaxes')
+  fetch('//api.xsnippet.org/syntaxes')
     .then(response => response.json())
     .then(json => dispatch(setSyntaxes(json)))
 );
 
 export const postSnippet = (snippet, onSuccess) => dispatch => (
-  fetch('http://api.xsnippet.org/snippets', {
+  fetch('//api.xsnippet.org/snippets', {
     method: 'POST',
     headers: {
       'Accept': 'application/json',

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -44,18 +44,18 @@ describe('actions', () => {
       first: {
         limit: '20',
         rel: 'first',
-        url: 'http://api.xsnippet.org/snippets?limit=20',
+        url: '//api.xsnippet.org/snippets?limit=20',
       },
       next: {
         limit: '20',
         marker: 28,
         rel: 'next',
-        url: 'http://api.xsnippet.org/snippets?limit=20&marker=28',
+        url: '//api.xsnippet.org/snippets?limit=20&marker=28',
       },
       prev: {
         limit: '20',
         rel: 'prev',
-        url: 'http://api.xsnippet.org/snippets?limit=20',
+        url: '//api.xsnippet.org/snippets?limit=20',
       },
     };
     const store = createStore();
@@ -82,10 +82,10 @@ describe('actions', () => {
         syntax: 'Python',
       },
     ];
-    const links = '<http://api.xsnippet.org/snippets?limit=20>; rel="first", <http://api.xsnippet.org/snippets?limit=20&marker=19>; rel="next", <http://api.xsnippet.org/snippets?limit=20&marker=59>; rel="prev"';
+    const links = '<//api.xsnippet.org/snippets?limit=20>; rel="first", <//api.xsnippet.org/snippets?limit=20&marker=19>; rel="next", <//api.xsnippet.org/snippets?limit=20&marker=59>; rel="prev"';
 
     fetchMock.getOnce(
-      'http://api.xsnippet.org/snippets?limit=20&marker=39',
+      '//api.xsnippet.org/snippets?limit=20&marker=39',
       {
         headers: { Link: links },
         body: snippets,
@@ -114,19 +114,19 @@ describe('actions', () => {
         first: {
           limit: '20',
           rel: 'first',
-          url: 'http://api.xsnippet.org/snippets?limit=20',
+          url: '//api.xsnippet.org/snippets?limit=20',
         },
         next: {
           limit: '20',
           marker: '19',
           rel: 'next',
-          url: 'http://api.xsnippet.org/snippets?limit=20&marker=19',
+          url: '//api.xsnippet.org/snippets?limit=20&marker=19',
         },
         prev: {
           limit: '20',
           marker: '59',
           rel: 'prev',
-          url: 'http://api.xsnippet.org/snippets?limit=20&marker=59',
+          url: '//api.xsnippet.org/snippets?limit=20&marker=59',
         },
       },
     });
@@ -145,10 +145,10 @@ describe('actions', () => {
         syntax: 'Python',
       },
     ];
-    const links = '<http://api.xsnippet.org/snippets?limit=20>; rel="first", <http://api.xsnippet.org/snippets?limit=20&marker=39>; rel="next"';
+    const links = '<//api.xsnippet.org/snippets?limit=20>; rel="first", <//api.xsnippet.org/snippets?limit=20&marker=39>; rel="next"';
 
     fetchMock.getOnce(
-      'http://api.xsnippet.org/snippets?limit=20',
+      '//api.xsnippet.org/snippets?limit=20',
       {
         headers: { Link: links },
         body: snippets,
@@ -177,13 +177,13 @@ describe('actions', () => {
         first: {
           limit: '20',
           rel: 'first',
-          url: 'http://api.xsnippet.org/snippets?limit=20',
+          url: '//api.xsnippet.org/snippets?limit=20',
         },
         next: {
           limit: '20',
           marker: '39',
           rel: 'next',
-          url: 'http://api.xsnippet.org/snippets?limit=20&marker=39',
+          url: '//api.xsnippet.org/snippets?limit=20&marker=39',
         },
       },
     });
@@ -219,7 +219,7 @@ describe('actions', () => {
       syntax: 'Go',
     };
 
-    fetchMock.getOnce(`http://api.xsnippet.org/snippets/${snippet.id}`, JSON.stringify(snippet));
+    fetchMock.getOnce(`//api.xsnippet.org/snippets/${snippet.id}`, JSON.stringify(snippet));
 
     const store = createStore();
     await store.dispatch(actions.fetchSnippet(snippet.id));
@@ -254,7 +254,7 @@ describe('actions', () => {
   it('should create an action to fetch syntaxes', async () => {
     const syntaxes = ['JavaScript', 'Python', 'Java', 'Go', 'Plain Text'];
 
-    fetchMock.getOnce('http://api.xsnippet.org/syntaxes', JSON.stringify(syntaxes));
+    fetchMock.getOnce('//api.xsnippet.org/syntaxes', JSON.stringify(syntaxes));
 
     const store = createStore();
     await store.dispatch(actions.fetchSyntaxes);
@@ -274,7 +274,7 @@ describe('actions', () => {
       syntax: 'JavaScript',
     };
 
-    fetchMock.postOnce('http://api.xsnippet.org/snippets', JSON.stringify(snippet));
+    fetchMock.postOnce('//api.xsnippet.org/snippets', JSON.stringify(snippet));
 
     const store = createStore();
     await store.dispatch(actions.postSnippet(snippet, () => {}));


### PR DESCRIPTION
Brand new XSnippet is going to be served using HTTPS protocol, however,
we use hardcoded http:// protocol on API URIs and this is a deal
breaker. Apparently, CORS requests made from https:// to http:// that
redirects to https:// is not going to work.

So we probably will go with both http:// and https:// protocols for API
for now in order to do not break local development environment, and in
order to be production/development compatible let's use protocol-less
schema in API URIs (e.g. //api.xsnippet.org) which means preserve schema
from the current page.