### PR TITLE
Add unique attribute for tags and fixed keyPress issue

### DIFF
--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -21,7 +21,10 @@ class NewSnippet extends React.Component {
       syntax: '', // eslint-disable-line react/no-unused-state
     };
     this.onKeyPress = (e) => {
-      if (e.which === 13) { e.preventDefault(); }
+      if (e.which === 13) { // keyCode for Enter button
+        e.preventDefault();
+        e.stopPropagation();
+      }
     };
     this.postSnippet = this.postSnippet.bind(this);
     this.onSyntaxClick = this.onSyntaxClick.bind(this);
@@ -85,6 +88,7 @@ class NewSnippet extends React.Component {
                 placeholder="Tags"
                 onAdded={this.onTagAdded}
                 onRemoved={this.onTagRemoved}
+                uniqueTags
               />
             </div>
             <div className="new-snippet-code">


### PR DESCRIPTION
To avoid duplications for tags we've forbid tags duplications
on component level, so user wouldn't be able to add two duplicate
tags on new Snippet form.
In addition, fixed onKeyPress issue so now it's not bubbling up
to submit form element and thus do not cause form subbmitting
when user tries to add new tag by clicking Enter button.