### PR TITLE
Replace CodeMirror with AceEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,6 +1465,11 @@
         "hoek": "4.2.0"
       }
     },
+    "brace": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.0.tgz",
+      "integrity": "sha1-FVzYBgdofcjLkI8N+U5ioDPB1WM="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1938,11 +1943,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
-    },
-    "codemirror": {
-      "version": "5.33.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.33.0.tgz",
-      "integrity": "sha512-HT6PKVqkwpzwB3jl5hXFoQteEWXbSWMzG3Z8RVYlx8hZwCOLCy4NU7vkSB3dYX3e6ORwRfGw4uFOXaw4rn/a9Q=="
     },
     "color": {
       "version": "0.11.4",
@@ -7003,6 +7003,16 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8926,10 +8936,16 @@
         "prop-types": "15.6.0"
       }
     },
-    "react-codemirror2": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-3.0.7.tgz",
-      "integrity": "sha512-l0iUmKZxKmMAtr9x/6lcHgAMmUZIVufRd0YdTKIe6Y/4Fv4z+0nvaInPituRep/hpeG5WUoEVaZoIV7qEltfDg=="
+    "react-ace": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.9.0.tgz",
+      "integrity": "sha512-r6Tuce6seG05g9kT2Tio6DWohy06knG7e5u9OfhvMquZL+Cyu4eqPf60K1Vi2RXlS3+FWrdG8Rinwu4+oQjjgw==",
+      "requires": {
+        "brace": "0.11.0",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "prop-types": "15.6.0"
+      }
     },
     "react-custom-scrollbars": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     }
   },
   "dependencies": {
-    "codemirror": "^5.33.0",
+    "brace": "^0.11.0",
     "immutable": "^3.8.2",
     "parse-link-header": "^1.0.1",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "react-codemirror2": "^3.0.7",
+    "react-ace": "^5.9.0",
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Controlled as CodeMirror } from 'react-codemirror2';
-
-import codemirror from 'codemirror';
-import 'codemirror/lib/codemirror.css';
+import AceEditor from 'react-ace';
 
 import Title from './common/Title';
 import Spinner from './common/Spinner';
@@ -41,7 +38,6 @@ class Snippet extends React.Component {
     if (!snippet) return <Spinner />;
 
     const snippetTitle = snippet.get('title') || `#${snippet.get('id')}, Untitled`;
-    const modeInfo = codemirror.findModeByName(snippet.get('syntax'));
 
     return (
       [
@@ -76,9 +72,20 @@ class Snippet extends React.Component {
             />
           </div>
           <div className="snippet-code">
-            <CodeMirror
+            <AceEditor
+              mode={snippet.get('syntax')}
+              width="100%"
+              height="100%"
+              setOptions={{
+                readOnly: true,
+                highlightActiveLine: false,
+                highlightGutterLine: false,
+                showFoldWidgets: false,
+                useWorker: false,
+                maxLines: Infinity,
+                showPrintMargin: false,
+              }}
               value={`${snippet.get('content')}`}
-              options={{ lineNumbers: true, readOnly: true, mode: modeInfo.mime }}
             />
             <div className="snippet-code-bottom-bar">
               <button className="snippet-button light">Raw</button>

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,4 +1,5 @@
-import codemirror from 'codemirror';
+import brace from 'brace';
+import 'brace/ext/modelist';
 
 const regExpEscape = string => string.replace(/[-[\]{}()*+?.,\\^$|]/g, '\\$&');
 
@@ -19,17 +20,20 @@ function download(text, name, mime) {
 }
 
 function downloadSnippet(snippet) {
-  // Despite using CodeMirror's modes as syntaxes on XSnippet API, we might
-  // imagine other setup when more syntaxes can be used on server. Hence, we
-  // must be prepared and fallback on "Plain Text" mode if we can't figure out
-  // what's extension and/or MIME type.
-  const modeInfo = codemirror.findModeByName(snippet.get('syntax'))
-              || codemirror.findModeByName('Plain Text');
+  const { modesByName } = brace.acequire('ace/ext/modelist');
 
+  // Despite using AceEditor's modes as syntaxes, we can imagine other setup
+  // when more or even other syntaxes can be used on API side. Hence, we better
+  // be prepared and fallback to "Text" mode if unknown syntaxes it is.
+  const mode = modesByName[snippet.get('syntax')] || modesByName.text;
+  const ext = mode.extensions.split('|')[0] || 'txt';
   const content = snippet.get('content');
-  const name = `${snippet.get('id')}.${modeInfo.ext[0]}`;
+  const name = `${snippet.get('id')}.${ext}`;
 
-  download(content, name, modeInfo.mime);
+  // Unfortunately, AceEditor doesn't maintain MIME type map so we don't know
+  // for sure which mode corresponds to which MIME type. Hence, let's use
+  // text/plain until we come up with better idea.
+  download(content, name, 'text/plain');
 }
 
 export { regExpEscape, downloadSnippet };

--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -1,32 +1,11 @@
 @import './common/variables.styl'
 @import './common/mixins.styl'
 
-.react-codemirror2,
-.CodeMirror
-  height: 100% !important
-  line-height: 1.4
+.snippet .ace_gutter-layer
+  width: 40px !important
 
-.new-snippet .react-codemirror2,
-.new-snippet .CodeMirror
-  color: text-dark !important
-
-.CodeMirror-gutter
-  &.CodeMirror-linenumbers
-    width: 39px
-
-.CodeMirror-sizer
-  margin-left: 39px
-  padding-top: 5px
-
-.CodeMirror-gutters
-  border-right: none
-
-.snippet .CodeMirror-line
-  padding-left: 20px !important
-
-.snippet .CodeMirror-cursor {
+.snippet .ace_cursor
   display: none !important
-}
 
 .react-tags
   display: flex

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,106 @@ module.exports = () => {
   // Use NODE_ENV environment variable to guess desired built type. Assume
   // production if nothing is passed.
   const isProduction = (process.env.NODE_ENV || 'production') === 'production';
+  const syntaxes = process.env.SYNTAXES
+    ? process.env.SYNTAXES.split(',').map(item => item.trim())
+    : [
+      'text',
+      'c_cpp',
+      'csharp',
+      'golang',
+      'java',
+      'javascript',
+      'php',
+      'perl',
+      'python',
+      'ruby',
+      'rust',
+      'css',
+      'html',
+      'objectivec',
+      'swift',
+      'clojure',
+      'lisp',
+      'haskell',
+      'scala',
+      'scheme',
+      'actionscript',
+      'ada',
+      'apache_conf',
+      'asciidoc',
+      'assembly_x86',
+      'batchfile',
+      'cobol',
+      'coffee',
+      'd',
+      'dart',
+      'diff',
+      'dockerfile',
+      'dot',
+      'ejs',
+      'elixir',
+      'elm',
+      'erlang',
+      'fortran',
+      'gitignore',
+      'glsl',
+      'gobstones',
+      'graphqlschema',
+      'groovy',
+      'haml',
+      'handlebars',
+      'haxe',
+      'hjson',
+      'ini',
+      'jade',
+      'json',
+      'jsp',
+      'jsx',
+      'julia',
+      'kotlin',
+      'latex',
+      'less',
+      'livescript',
+      'lua',
+      'makefile',
+      'markdown',
+      'matlab',
+      'mel',
+      'mysql',
+      'nix',
+      'nsis',
+      'ocaml',
+      'pascal',
+      'pgsql',
+      'powershell',
+      'prolog',
+      'protobuf',
+      'r',
+      'rdoc',
+      'rst',
+      'sass',
+      'scad',
+      'scss',
+      'sh',
+      'sjs',
+      'smarty',
+      'sql',
+      'stylus',
+      'svg',
+      'tcl',
+      'tex',
+      'textile',
+      'toml',
+      'tsx',
+      'twig',
+      'typescript',
+      'vala',
+      'vbscript',
+      'verilog',
+      'vhdl',
+      'xml',
+      'yaml',
+      'django'];
 
   let conf = {
     // Expose source map even for production because XSnippet is an Open Source
@@ -29,10 +129,16 @@ module.exports = () => {
       app: [
         path.resolve(__dirname, 'src', 'index.jsx'),
 
-        // Bundle CodeMirror's syntaxes along with main application. There are
-        // around 120 syntaxes and we, of course, do not want to import all of
+        // Bundle AceEditor's syntaxes along with main application. There are
+        // around 150 syntaxes and we, of course, do not want to import all of
         // them from within the application, hence this hack.
-        ...glob.sync(path.resolve(__dirname, 'node_modules', 'codemirror', 'mode', '*', '*.js')),
+        ...glob.sync(path.resolve(
+          __dirname,
+          'node_modules',
+          'brace',
+          'mode',
+          `@(${syntaxes.join('|')}).js`,
+        )),
       ],
     },
 
@@ -139,6 +245,12 @@ module.exports = () => {
   if (isProduction) {
     conf = merge(conf, {
       plugins: [
+        // Worker is a sort of background linter integrated in AceEditor that
+        // can show errors for some syntaxes (e.g. JavaScript or XML). It's
+        // pretty heavy (~1Mb) and we have no plans to use it, so we just
+        // aggressively strip this code out of build.
+        new webpack.IgnorePlugin(/worker/, /brace/),
+
         // Enable source maps if they are specified in devtool option. By some
         // funny reason UglifyJSPlugin does not check devtool option and won't
         // produce them unless its sourceMap option set to true.


### PR DESCRIPTION
AceEditor is much more functional than CodeMirror as well as there are
bunch of extensions/styles for the AceEditor in the Internet. For
instance it provides an API to annotate lines or highlight them, which
CodeMirror lacks of.

This commit replaces CodeMirror with AceEditor, though some style
enhacenements are required before going live.

Closes: #43 
Closes: #44 