### PR TITLE
Do not reset selected item in ListBox

### DIFF
--- a/src/components/ListBox.jsx
+++ b/src/components/ListBox.jsx
@@ -25,9 +25,8 @@ class ListBox extends React.Component {
       if (!selected) return;
       selected = selected.value;
       nextProps.onClick(selected);
+      this.setState({ selected });
     }
-
-    this.setState({ selected });
   }
 
   onClick(e) {


### PR DESCRIPTION
By some funny reason we are unable to select new item in the ListBox. I
have no idea why it worked before but apparently there were a problem in
state management logic.

Despite having plans to rewrite things in ListBox to make it simpler and
even more general, let's fix the logic now in order to properly manage
currently selected syntax.

In few words, the issue is that React components have asynchronus state
and apparently by the time 'componentWillReceiveProps' is called the
state is not updated. So we should not reset the state in this case.