### PR TITLE
Fix for code area styles after moving to Ace

### DIFF
--- a/src/styles/NewSnippet.styl
+++ b/src/styles/NewSnippet.styl
@@ -23,7 +23,7 @@ lang-bar-width = 230px
   &-code
     flex: 1
     position: relative
-    padding: 0 20px 63px 0
+    padding: 0 0 63px 0
     &-wrapper
       display: flex
       flex-flow: column nowrap

--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -1,11 +1,22 @@
 @import './common/variables.styl'
 @import './common/mixins.styl'
 
-.snippet .ace_gutter-layer
-  width: 40px !important
+.snippet
+  .ace_cursor
+    display: none !important
+  .ace_gutter
+    &-layer
+      width: 40px !important
+    &-cell
+      padding-right: 5px !important
+      padding-left: 0
+  .ace_scroller
+    margin-left: 15px !important
+  .ace_content
+    width: calc(100% - 15px) !important
 
-.snippet .ace_cursor
-  display: none !important
+.new-snippet .ace_editor
+  min-height 100% !important
 
 .react-tags
   display: flex


### PR DESCRIPTION
Due to different type of basic styles between COdeMirror and Ace
there was a need to add a few new lines of styles to ovewrite.