### PR TITLE
Explicitly require textmate theme

### DIFF
--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -5,6 +5,7 @@ import Tags from 'react-tagging-input';
 
 import brace from 'brace';
 import 'brace/ext/modelist';
+import 'brace/theme/textmate';
 
 import Title from './common/Title';
 import ListBoxWithSearch from './ListBoxWithSearch';
@@ -107,6 +108,7 @@ class NewSnippet extends React.Component {
                 width="100%"
                 height="100%"
                 focus
+                theme="textmate"
                 setOptions={{
                   showFoldWidgets: false,
                   useWorker: false,

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import AceEditor from 'react-ace';
 
+import 'brace/theme/textmate';
+
 import Title from './common/Title';
 import Spinner from './common/Spinner';
 import * as actions from '../actions';
@@ -76,6 +78,7 @@ class Snippet extends React.Component {
               mode={snippet.get('syntax')}
               width="100%"
               height="100%"
+              theme="textmate"
               setOptions={{
                 readOnly: true,
                 highlightActiveLine: false,


### PR DESCRIPTION
Apparently Ace (Brace) editor uses TextMate color scheme by default and
we used to rely on this. However, if no theme is imported explicitly,
Ace will try to dynamically fetch it and will end up with 404 error in
browser's console, since we don't have the file and everything in
bundled in one file.