### PR TITLE
Fix for last line of code for snippet page

### DIFF
--- a/src/styles/Snippet.styl
+++ b/src/styles/Snippet.styl
@@ -62,9 +62,7 @@
   &-code
     flex: 1
     position: relative
-    padding-bottom: 62px
     &-bottom-bar
-      position: absolute
       bottom: 0
       left: 0
       right: 0


### PR DESCRIPTION
There was an issue with incorect styles for last line of code: it
seemed that bottom bar bottom was over last line in Safari.