### PR TITLE
Fix tags so they can't contain spaces

### DIFF
--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -49,9 +49,11 @@ class NewSnippet extends React.Component {
   }
 
   onTagAdded(tag) {
-    this.setState({ tags: [...this.state.tags, tag] }, () => {
-      this.recalcLangHeaderHeight();
-    });
+    if (tag) {
+      this.setState({ tags: [...this.state.tags, tag] }, () => {
+        this.recalcLangHeaderHeight();
+      });
+    }
   }
 
   onTagRemoved(tag) {
@@ -109,7 +111,7 @@ class NewSnippet extends React.Component {
                 placeholder="Tags"
                 onAdded={this.onTagAdded}
                 onRemoved={this.onTagRemoved}
-                addKeys={[13, 9]}
+                addKeys={[32, 13, 9]}
                 uniqueTags
               />
             </div>


### PR DESCRIPTION
Forbid multiple words within one tag to be consistent with back-end
implementation for snippet tags