### PR TITLE
Fix date parser for Recent snippet and Snippet pages

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -47,7 +47,8 @@ function copyToClipboard(e, id) {
 function parseDate(d) {
   const date = new Date(d);
   const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
-  const month = date.getMonth() < 10 ? `0${date.getMonth()}` : date.getMonth();
+  const parsedMonth = date.getMonth() + 1;
+  const month = parsedMonth < 10 ? `0${parsedMonth}` : parsedMonth;
   return `${day}.${month}.${date.getFullYear()}`;
 }
 

--- a/tests/helpers/index.test.js
+++ b/tests/helpers/index.test.js
@@ -1,0 +1,15 @@
+import { parseDate } from '../../src/helpers';
+
+describe('helpers: parseDate', () => {
+  it('should return properly formated date', () => {
+    const incomeDate = '03/11/2017';
+
+    expect(parseDate(incomeDate)).toEqual('11.03.2017');
+  });
+
+  it('should return properly formated date for Jan', () => {
+    const incomeDate = '01/01/2018';
+
+    expect(parseDate(incomeDate)).toEqual('01.01.2018');
+  });
+});


### PR DESCRIPTION
Since built-in method .getMonth() returns int from 0 to 11 where 0 is a
January and 11 is a December, there was an error in custom date parse
function which is fixed in this commit