### PR TITLE
Enable search through snippet when focus within code editor

### DIFF
--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -36,6 +36,10 @@ class NewSnippet extends React.Component {
       document.getElementsByClassName('new-snippet-lang-header')[0]
         .setAttribute('style', `height:${newSnippetHeaderHeight}px`);
     };
+    this.onEditorLoad = (editor) => {
+      // we want to disable built-in find in favor of browser's one
+      editor.commands.removeCommand('find');
+    };
     this.postSnippet = this.postSnippet.bind(this);
     this.onSyntaxClick = this.onSyntaxClick.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
@@ -122,6 +126,7 @@ class NewSnippet extends React.Component {
                 height="100%"
                 focus
                 theme="textmate"
+                onLoad={this.onEditorLoad}
                 setOptions={{
                   showFoldWidgets: false,
                   useWorker: false,

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -21,6 +21,10 @@ class Snippet extends React.Component {
     this.copyClipboard = (e) => {
       copyToClipboard(e, 'embedded');
     };
+    this.onEditorLoad = (editor) => {
+      // we want to disable built-in find in favor of browser's one
+      editor.commands.removeCommand('find');
+    };
   }
 
   componentDidMount() {
@@ -96,6 +100,7 @@ class Snippet extends React.Component {
               width="100%"
               height="100%"
               theme="textmate"
+              onLoad={this.onEditorLoad}
               setOptions={{
                 readOnly: true,
                 highlightActiveLine: false,


### PR DESCRIPTION
To improve UX and let user search through existing code snippet,
this commit contains missed ace extension that was made to let users
search through code
Closes: #67