### PR TITLE
Fix issue for ios mobile devices when code editor is hidden on them

### DIFF
--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -52,3 +52,6 @@
       a
         margin-left: 3px
         cursor: pointer
+
+.snippet-code .ace_text-input-ios
+  position: relative !important


### PR DESCRIPTION
Some very strange class was applied to code editor when opening on ios
mobile devices. This class was ment to hide code editor for some unclear
reasons in a very ugly way. This commit overwrites this styles to let
users with ios mobile devices see code snippet.