### PR TITLE
Fix for native input type='submit' styles

### DIFF
--- a/src/styles/NewSnippet.styl
+++ b/src/styles/NewSnippet.styl
@@ -55,6 +55,8 @@ lang-bar-width-tablet = 170px
         color: text-light
         font-size: 15px
         text-align: center
+        -webkit-appearance: none // we need this styles to overwrite safary's styles for input with type='submit'
+        -webkit-border-radius: 0
         &:hover,
         &:focus
           background-color: snippet-post-button-active


### PR DESCRIPTION
Since input with type='submit' styles have bigger value than ones that
we declared in code, we want completely backward behaviour. So we added
a few styles with webkit prefix to reach what we want.