### PR TITLE
Remove title from NewSnippet, RecentSnippets and Snippet pages

### DIFF
--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -7,7 +7,6 @@ import brace from 'brace';
 import 'brace/ext/modelist';
 import 'brace/theme/textmate';
 
-import Title from './common/Title';
 import ListBoxWithSearch from './ListBoxWithSearch';
 import * as actions from '../actions';
 
@@ -91,65 +90,62 @@ class NewSnippet extends React.Component {
     }));
 
     return (
-      [
-        <Title title="New snippet" key="New Snippet Title" />,
-        <form
-          className="new-snippet"
-          key="New Snippet"
-          onKeyPress={this.onKeyPress}
-          onSubmit={this.postSnippet}
-          role="presentation"
-        >
-          <div className="new-snippet-code-wrapper">
-            <div className="new-snippet-code-header">
-              <input
-                className="input"
-                placeholder="Title"
-                name="title"
-                type="text"
-                value={this.state.title}
-                onChange={this.onInputChange}
-              />
-              <Tags
-                tags={this.state.tags}
-                placeholder="Tags"
-                onAdded={this.onTagAdded}
-                onRemoved={this.onTagRemoved}
-                addKeys={[32, 13, 9]}
-                uniqueTags
-              />
-            </div>
-            <div className="new-snippet-code">
-              <AceEditor
-                mode={mode.name}
-                width="100%"
-                height="100%"
-                focus
-                theme="textmate"
-                onLoad={this.onEditorLoad}
-                setOptions={{
-                  showFoldWidgets: false,
-                  useWorker: false,
-                  maxLines: Infinity,
-                  showPrintMargin: false,
-                }}
-                value={this.state.content}
-                onChange={(content) => { this.setState({ content }); }}
-              />
-
-              <div className="new-snippet-code-bottom-bar">
-                <input type="submit" value="POST SNIPPET" />
-              </div>
-            </div>
-          </div>
-          <div className="new-snippet-lang-wrapper">
-            <ListBoxWithSearch
-              items={syntaxes}
-              onClick={this.onSyntaxClick}
+      <form
+        className="new-snippet"
+        key="New Snippet"
+        onKeyPress={this.onKeyPress}
+        onSubmit={this.postSnippet}
+        role="presentation"
+      >
+        <div className="new-snippet-code-wrapper">
+          <div className="new-snippet-code-header">
+            <input
+              className="input"
+              placeholder="Title"
+              name="title"
+              type="text"
+              value={this.state.title}
+              onChange={this.onInputChange}
+            />
+            <Tags
+              tags={this.state.tags}
+              placeholder="Tags"
+              onAdded={this.onTagAdded}
+              onRemoved={this.onTagRemoved}
+              addKeys={[32, 13, 9]}
+              uniqueTags
             />
           </div>
-        </form>,
-      ]
+          <div className="new-snippet-code">
+            <AceEditor
+              mode={mode.name}
+              width="100%"
+              height="100%"
+              focus
+              theme="textmate"
+              onLoad={this.onEditorLoad}
+              setOptions={{
+                showFoldWidgets: false,
+                useWorker: false,
+                maxLines: Infinity,
+                showPrintMargin: false,
+              }}
+              value={this.state.content}
+              onChange={(content) => { this.setState({ content }); }}
+            />
+
+            <div className="new-snippet-code-bottom-bar">
+              <input type="submit" value="POST SNIPPET" />
+            </div>
+          </div>
+        </div>
+        <div className="new-snippet-lang-wrapper">
+          <ListBoxWithSearch
+            items={syntaxes}
+            onClick={this.onSyntaxClick}
+          />
+        </div>
+      </form>
     );
   }
 }

--- a/src/components/RecentSnippets.jsx
+++ b/src/components/RecentSnippets.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import Title from './common/Title';
 import RecentSnippetItem from './RecentSnippetItem';
 import * as actions from '../actions';
 
@@ -54,7 +53,6 @@ class RecentSnippets extends React.Component {
     const newer = pagination.get('prev');
 
     return ([
-      <Title title="Recent snippets" additionalClass="recent-title" key="title-recent" />,
       <ul className="recent-snippet" key="recent-snippet">
         {recent.map(id => <RecentSnippetItem key={id} snippet={snippets.get(id)} />)}
       </ul>,

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -5,7 +5,6 @@ import brace from 'brace';
 
 import 'brace/theme/textmate';
 
-import Title from './common/Title';
 import Spinner from './common/Spinner';
 import * as actions from '../actions';
 import { downloadSnippet, copyToClipboard, formatDate } from '../helpers';
@@ -54,68 +53,65 @@ class Snippet extends React.Component {
     const rawUrl = process.env.RAW_SNIPPETS_URL_FORMAT.replace('%s', snippet.get('id'));
 
     return (
-      [
-        <Title title="Snippet" key="Snippet title" />,
-        <div className="snippet" key="Snippet">
-          <div className="snippet-header">
-            <div className="snippet-data">
-              <span className="snippet-data-title">{snippetTitle}</span>
-              <div className="snippet-data-tags">
-                {snippet.get('tags').map(item => <span className="snippet-data-tag" key={item}>{item}</span>)}
-              </div>
-              <span className="snippet-data-meta">{formatDate(snippet.get('created_at'))}, by Guest</span>
+      <div className="snippet" key="Snippet">
+        <div className="snippet-header">
+          <div className="snippet-data">
+            <span className="snippet-data-title">{snippetTitle}</span>
+            <div className="snippet-data-tags">
+              {snippet.get('tags').map(item => <span className="snippet-data-tag" key={item}>{item}</span>)}
             </div>
-            <div className="snippet-data-actions">
-              <span className="snippet-data-lang">{syntax}</span>
-              <div>
-                <a href={rawUrl} className="snippet-button">Raw</a>
-                <button className="snippet-button" onClick={this.download}>Download</button>
-                <button
-                  className={`snippet-button ${this.state.isShowEmbed}`}
-                  key="snippet-details"
-                  onClick={this.toggleEmbed}
-                  onKeyPress={this.toggleEmbed}
-                >
-                  Embed
-                </button>
-              </div>
+            <span className="snippet-data-meta">{formatDate(snippet.get('created_at'))}, by Guest</span>
+          </div>
+          <div className="snippet-data-actions">
+            <span className="snippet-data-lang">{syntax}</span>
+            <div>
+              <a href={rawUrl} className="snippet-button">Raw</a>
+              <button className="snippet-button" onClick={this.download}>Download</button>
+              <button
+                className={`snippet-button ${this.state.isShowEmbed}`}
+                key="snippet-details"
+                onClick={this.toggleEmbed}
+                onKeyPress={this.toggleEmbed}
+              >
+                Embed
+              </button>
             </div>
           </div>
-          <div className={`snippet-embed ${this.state.isShowEmbed}`}>
-            <span className="snippet-embed-close" onClick={this.toggleEmbed} role="presentation" />
-            <p className="snippet-embed-text">
-              In order to embed this content into your website or blog,
-              simply copy and paste code provided below:
-            </p>
-            <input
-              id="embedded"
-              className="input"
-              type="text"
-              defaultValue={`<script src='http://xsnippet.org/${snippet.get('id')}/embed/'></script>`}
-            />
-            <button className="snippet-button embed" onClick={this.copyClipboard}>Copy</button>
-          </div>
-          <div className="snippet-code">
-            <AceEditor
-              mode={snippet.get('syntax')}
-              width="100%"
-              height="100%"
-              theme="textmate"
-              onLoad={this.onEditorLoad}
-              setOptions={{
-                readOnly: true,
-                highlightActiveLine: false,
-                highlightGutterLine: false,
-                showFoldWidgets: false,
-                useWorker: false,
-                maxLines: Infinity,
-                showPrintMargin: false,
-              }}
-              value={`${snippet.get('content')}`}
-            />
-          </div>
-        </div>,
-      ]
+        </div>
+        <div className={`snippet-embed ${this.state.isShowEmbed}`}>
+          <span className="snippet-embed-close" onClick={this.toggleEmbed} role="presentation" />
+          <p className="snippet-embed-text">
+            In order to embed this content into your website or blog,
+            simply copy and paste code provided below:
+          </p>
+          <input
+            id="embedded"
+            className="input"
+            type="text"
+            defaultValue={`<script src='http://xsnippet.org/${snippet.get('id')}/embed/'></script>`}
+          />
+          <button className="snippet-button embed" onClick={this.copyClipboard}>Copy</button>
+        </div>
+        <div className="snippet-code">
+          <AceEditor
+            mode={snippet.get('syntax')}
+            width="100%"
+            height="100%"
+            theme="textmate"
+            onLoad={this.onEditorLoad}
+            setOptions={{
+              readOnly: true,
+              highlightActiveLine: false,
+              highlightGutterLine: false,
+              showFoldWidgets: false,
+              useWorker: false,
+              maxLines: Infinity,
+              showPrintMargin: false,
+            }}
+            value={`${snippet.get('content')}`}
+          />
+        </div>
+      </div>
     );
   }
 }

--- a/src/styles/NewSnippet.styl
+++ b/src/styles/NewSnippet.styl
@@ -7,7 +7,7 @@ lang-bar-width-tablet = 170px
 
 .new-snippet
   display: flex
-  min-height: 75vh
+  min-height: 83vh
   background-color: snippet-content-light
   box-shadow: 0 2px 2px 0 border-dark
   &-code,


### PR DESCRIPTION
To leave user a little bit more space on pages (statisctic shows that
biggest part of our users use 13inch screens) so it essentialy to have
this free space