### PR TITLE
Fix snippet animation overflow issue

### DIFF
--- a/src/styles/Snippet.styl
+++ b/src/styles/Snippet.styl
@@ -92,6 +92,7 @@ button-group-width = 312px
     transition: max-height .5s ease-in
     background-color: snippet-header-embed
     border-left: 40px solid snippet-header-embed-dark
+    overflow: hidden
     &.false
       max-height: 0
       transition: max-height .5s ease-out


### PR DESCRIPTION
Embed section content was not hidden entirely behind small snippets. It was fixed by setting hidden overflow to embed block.