### PR TITLE
Set 'private' flag in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,6 @@
     "build": "webpack",
     "start": "cross-env NODE_ENV=development webpack-dev-server --open",
     "test": "jest --coverage"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
XSnippet Web is a single page application, and, therefore, we have no
plans to publish it on npm. In order to prevent accidental publication,
let's set '"private": false' option.