### PR TITLE
Do not pass node_modules to Babel

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,16 +154,7 @@ module.exports = () => {
         // Transpile ES2015+ down to ES5.
         {
           test: /\.jsx?$/,
-          include: [
-            path.resolve(__dirname, 'src'),
-            // Joi and its dependencies are not distributed as ES5 code, so
-            // we need to transpile them as well; otherwise, UglifyJS will
-            // fail to minify the sources.
-            path.resolve(__dirname, 'node_modules', 'joi'),
-            path.resolve(__dirname, 'node_modules', 'hoek'),
-            path.resolve(__dirname, 'node_modules', 'topo'),
-            path.resolve(__dirname, 'node_modules', 'isemail'),
-          ],
+          include: path.resolve(__dirname, 'src'),
           use: ['babel-loader'],
         },
 


### PR DESCRIPTION
We used to pass Joi and its dependencies to Babel because they are
distributing as ES6 libraries, not as ES5. While browsers are usually
good enough to eat this, UglifyJS fails to process non ES5 blocks.

Fortunately, we've upgraded to webpack 4 that comes with new version of
uglifyjs-webpack-plugin that depends on uglify-es module rather than on
uglify-js. The former supports non ES5 blocks so from now on any non ES5
code processed by uglifyjs-webpack-plugin will be transpiled to ES5.