### PR TITLE
Rename helpers to misc and change exports

### DIFF
--- a/src/components/ListBoxWithSearch.jsx
+++ b/src/components/ListBoxWithSearch.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import ListBox from './ListBox';
-import { regExpEscape } from '../helpers';
+import * as misc from '../misc';
 
 class ListBoxWithSearch extends React.PureComponent {
   constructor(props) {
@@ -31,7 +31,7 @@ class ListBoxWithSearch extends React.PureComponent {
     // Filter out only those items that match search query. If no query is
     // set, do nothing and use the entire set.
     if (searchQuery) {
-      const regExp = new RegExp(regExpEscape(searchQuery), 'gi');
+      const regExp = new RegExp(misc.regExpEscape(searchQuery), 'gi');
       items = items.filter(item => item.name.match(regExp));
     }
 

--- a/src/components/RecentSnippetItem.jsx
+++ b/src/components/RecentSnippetItem.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import brace from 'brace';
 
-import { downloadSnippet, formatDate } from '../helpers';
+import * as misc from '../misc';
 
 const RecentSnippetItem = ({ snippet }) => {
   const { modesByName } = brace.acequire('ace/ext/modelist');
   const mode = modesByName[snippet.get('syntax')] || modesByName.text;
   const syntax = mode.caption;
   const snippetTitle = snippet.get('title') || `#${snippet.get('id')}, Untitled`;
-  const download = () => downloadSnippet(snippet);
+  const download = () => misc.downloadSnippet(snippet);
   const rawUrl = process.env.RAW_SNIPPETS_URL_FORMAT.replace('%s', snippet.get('id'));
 
   return (
@@ -21,7 +21,7 @@ const RecentSnippetItem = ({ snippet }) => {
             {snippet.get('tags').map(item => <span className="recent-snippet-meta-tag" key={item}>{item}</span>)}
           </div>
         </div>
-        <span className="recent-snippet-meta-info">{formatDate(snippet.get('created_at'))}, by Guest</span>
+        <span className="recent-snippet-meta-info">{misc.formatDate(snippet.get('created_at'))}, by Guest</span>
       </div>
       <div className="recent-snippet-actions">
         <span className="recent-snippet-lang">{syntax}</span>

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -7,7 +7,7 @@ import 'brace/theme/textmate';
 
 import Spinner from './common/Spinner';
 import * as actions from '../actions';
-import { downloadSnippet, copyToClipboard, formatDate } from '../helpers';
+import * as misc from '../misc';
 
 import '../styles/Snippet.styl';
 
@@ -18,7 +18,7 @@ export class Snippet extends React.Component {
     this.toggleEmbed = this.toggleEmbed.bind(this);
     this.download = this.download.bind(this);
     this.copyClipboard = (e) => {
-      copyToClipboard(e, 'embedded');
+      misc.copyToClipboard(e, 'embedded');
     };
     this.onEditorLoad = (editor) => {
       // we want to disable built-in find in favor of browser's one
@@ -34,7 +34,7 @@ export class Snippet extends React.Component {
   }
 
   download() {
-    downloadSnippet(this.props.snippet);
+    misc.downloadSnippet(this.props.snippet);
   }
 
   toggleEmbed() {
@@ -60,7 +60,7 @@ export class Snippet extends React.Component {
             <div className="snippet-data-tags">
               {snippet.get('tags').map(item => <span className="snippet-data-tag" key={item}>{item}</span>)}
             </div>
-            <span className="snippet-data-meta">{formatDate(snippet.get('created_at'))}, by Guest</span>
+            <span className="snippet-data-meta">{misc.formatDate(snippet.get('created_at'))}, by Guest</span>
           </div>
           <div className="snippet-data-actions">
             <span className="snippet-data-lang">{syntax}</span>

--- a/src/misc/index.js
+++ b/src/misc/index.js
@@ -1,9 +1,9 @@
 import brace from 'brace';
 import 'brace/ext/modelist';
 
-const regExpEscape = string => string.replace(/[-[\]{}()*+?.,\\^$|]/g, '\\$&');
+export const regExpEscape = string => string.replace(/[-[\]{}()*+?.,\\^$|]/g, '\\$&');
 
-function download(text, name, mime) {
+export function download(text, name, mime) {
   // It seems it's the only way to initiate file downloading from JavaScript
   // as of Jan 7, 2018. If you read this and know a better way, please submit
   // a pull request! ;)
@@ -19,7 +19,7 @@ function download(text, name, mime) {
   document.body.removeChild(element);
 }
 
-function downloadSnippet(snippet) {
+export function downloadSnippet(snippet) {
   const { modesByName } = brace.acequire('ace/ext/modelist');
 
   // Despite using AceEditor's modes as syntaxes, we can imagine other setup
@@ -36,7 +36,7 @@ function downloadSnippet(snippet) {
   download(content, name, 'text/plain');
 }
 
-function copyToClipboard(e, id) {
+export function copyToClipboard(e, id) {
   document.getElementById(id).select();
   document.execCommand('copy');
   e.target.focus();
@@ -44,10 +44,8 @@ function copyToClipboard(e, id) {
 
 // This function is here just because I don't want to pull the whole moment.js
 // only for one tiny date
-function formatDate(d) {
+export function formatDate(d) {
   const ISOdate = d.split('T')[0];
 
   return ISOdate.split('-').reverse().join('.');
 }
-
-export { regExpEscape, downloadSnippet, copyToClipboard, formatDate };

--- a/tests/helpers/index.test.js
+++ b/tests/helpers/index.test.js
@@ -1,15 +1,15 @@
-import { formatDate } from '../../src/helpers';
+import * as misc from '../../src/misc';
 
-describe('helpers: formatDate', () => {
+describe('misc: formatDate', () => {
   it('should return properly formated date', () => {
     const incomeDate = '2018-03-11T15:28:19';
 
-    expect(formatDate(incomeDate)).toEqual('11.03.2018');
+    expect(misc.formatDate(incomeDate)).toEqual('11.03.2018');
   });
 
   it('should return properly format7ed date for Jan', () => {
     const incomeDate = '2018-01-01T23:28:19';
 
-    expect(formatDate(incomeDate)).toEqual('01.01.2018');
+    expect(misc.formatDate(incomeDate)).toEqual('01.01.2018');
   });
 });


### PR DESCRIPTION
In this ticket one-object export was replaced with one-function export
for helpers file (which is called misc now) and imported now with namespace.
This was done in name of Ihor's health :p