### PR TITLE
Add support for v1 api

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -15,7 +15,7 @@ export const fetchRecentSnippets = marker => (dispatch) => {
   let qs = ''
   if (marker) { qs = `&marker=${marker}` }
 
-  return fetch(misc.getApiUri(`/snippets?limit=20${qs}`))
+  return fetch(misc.getApiUri(`snippets?limit=20${qs}`))
     .then((response) => {
       const links = parseLinkHeader(response.headers.get('Link'))
 
@@ -31,7 +31,7 @@ export const setSnippet = snippet => ({
 })
 
 export const fetchSnippet = id => dispatch => (
-  fetch(misc.getApiUri(`/snippets/${id}`))
+  fetch(misc.getApiUri(`snippets/${id}`))
     .then(response => response.json())
     .then(json => dispatch(setSnippet(json)))
 )
@@ -42,13 +42,13 @@ export const setSyntaxes = syntaxes => ({
 })
 
 export const fetchSyntaxes = dispatch => (
-  fetch(misc.getApiUri('/syntaxes'))
+  fetch(misc.getApiUri('syntaxes'))
     .then(response => response.json())
     .then(json => dispatch(setSyntaxes(json)))
 )
 
 export const postSnippet = (snippet, onSuccess) => dispatch => (
-  fetch(misc.getApiUri('/snippets'), {
+  fetch(misc.getApiUri('snippets'), {
     method: 'POST',
     headers: {
       'Accept': 'application/json',

--- a/src/misc/index.js
+++ b/src/misc/index.js
@@ -52,6 +52,6 @@ export function formatDate(d) {
   return ISOdate.split('-').reverse().join('.')
 }
 
-export function getApiUri(endpoint) {
-  return `${conf.API_BASE_URI}${endpoint}`
+export function getApiUri(endpoint, version = 'v1') {
+  return `${conf.API_BASE_URI}/${version}/${endpoint}`
 }

--- a/tests/helpers/index.test.js
+++ b/tests/helpers/index.test.js
@@ -1,15 +1,29 @@
 import * as misc from '../../src/misc'
 
-describe('misc: formatDate', () => {
+describe('misc', () => {
   it('should return properly formated date', () => {
     const incomeDate = '2018-03-11T15:28:19'
 
     expect(misc.formatDate(incomeDate)).toEqual('11.03.2018')
   })
 
-  it('should return properly format7ed date for Jan', () => {
+  it('should return properly formatted date for Jan', () => {
     const incomeDate = '2018-01-01T23:28:19'
 
     expect(misc.formatDate(incomeDate)).toEqual('01.01.2018')
+  })
+
+  it('should construct correct url with default api version', () => {
+    process.env.API_BASE_URI = '//api.xsnippet.org'
+    const f = misc.getApiUri('snippets')
+
+    expect(f).toBe(`${process.env.API_BASE_URI}/v1/snippets`)
+  })
+
+  it('should construct correct url with passed api version', () => {
+    process.env.API_BASE_URI = '//api.xsnippet.org'
+    const f = misc.getApiUri('snippets', 'v404')
+
+    expect(f).toBe(`${process.env.API_BASE_URI}/v404/snippets`)
   })
 })

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -44,18 +44,18 @@ describe('actions', () => {
       first: {
         limit: '20',
         rel: 'first',
-        url: '//api.xsnippet.org/snippets?limit=20',
+        url: '//api.xsnippet.org/v1/snippets?limit=20',
       },
       next: {
         limit: '20',
         marker: 28,
         rel: 'next',
-        url: '//api.xsnippet.org/snippets?limit=20&marker=28',
+        url: '//api.xsnippet.org/v1/snippets?limit=20&marker=28',
       },
       prev: {
         limit: '20',
         rel: 'prev',
-        url: '//api.xsnippet.org/snippets?limit=20',
+        url: '//api.xsnippet.org/v1/snippets?limit=20',
       },
     }
     const store = createStore()
@@ -82,10 +82,10 @@ describe('actions', () => {
         syntax: 'Python',
       },
     ]
-    const links = '<//api.xsnippet.org/snippets?limit=20>; rel="first", <//api.xsnippet.org/snippets?limit=20&marker=19>; rel="next", <//api.xsnippet.org/snippets?limit=20&marker=59>; rel="prev"'
+    const links = '<//api.xsnippet.org/v1/snippets?limit=20>; rel="first", <//api.xsnippet.org/v1/snippets?limit=20&marker=19>; rel="next", <//api.xsnippet.org/v1/snippets?limit=20&marker=59>; rel="prev"'
 
     fetchMock.getOnce(
-      '//api.xsnippet.org/snippets?limit=20&marker=39',
+      '//api.xsnippet.org/v1/snippets?limit=20&marker=39',
       {
         headers: { Link: links },
         body: snippets,
@@ -114,19 +114,19 @@ describe('actions', () => {
         first: {
           limit: '20',
           rel: 'first',
-          url: '//api.xsnippet.org/snippets?limit=20',
+          url: '//api.xsnippet.org/v1/snippets?limit=20',
         },
         next: {
           limit: '20',
           marker: '19',
           rel: 'next',
-          url: '//api.xsnippet.org/snippets?limit=20&marker=19',
+          url: '//api.xsnippet.org/v1/snippets?limit=20&marker=19',
         },
         prev: {
           limit: '20',
           marker: '59',
           rel: 'prev',
-          url: '//api.xsnippet.org/snippets?limit=20&marker=59',
+          url: '//api.xsnippet.org/v1/snippets?limit=20&marker=59',
         },
       },
     })
@@ -145,10 +145,10 @@ describe('actions', () => {
         syntax: 'Python',
       },
     ]
-    const links = '<//api.xsnippet.org/snippets?limit=20>; rel="first", <//api.xsnippet.org/snippets?limit=20&marker=39>; rel="next"'
+    const links = '<//api.xsnippet.org/v1/snippets?limit=20>; rel="first", <//api.xsnippet.org/v1/snippets?limit=20&marker=39>; rel="next"'
 
     fetchMock.getOnce(
-      '//api.xsnippet.org/snippets?limit=20',
+      '//api.xsnippet.org/v1/snippets?limit=20',
       {
         headers: { Link: links },
         body: snippets,
@@ -177,13 +177,13 @@ describe('actions', () => {
         first: {
           limit: '20',
           rel: 'first',
-          url: '//api.xsnippet.org/snippets?limit=20',
+          url: '//api.xsnippet.org/v1/snippets?limit=20',
         },
         next: {
           limit: '20',
           marker: '39',
           rel: 'next',
-          url: '//api.xsnippet.org/snippets?limit=20&marker=39',
+          url: '//api.xsnippet.org/v1/snippets?limit=20&marker=39',
         },
       },
     })
@@ -219,7 +219,7 @@ describe('actions', () => {
       syntax: 'Go',
     }
 
-    fetchMock.getOnce(`//api.xsnippet.org/snippets/${snippet.id}`, JSON.stringify(snippet))
+    fetchMock.getOnce(`//api.xsnippet.org/v1/snippets/${snippet.id}`, JSON.stringify(snippet))
 
     const store = createStore()
     await store.dispatch(actions.fetchSnippet(snippet.id))
@@ -254,7 +254,7 @@ describe('actions', () => {
   it('should create an action to fetch syntaxes', async () => {
     const syntaxes = ['JavaScript', 'Python', 'Java', 'Go', 'Plain Text']
 
-    fetchMock.getOnce('//api.xsnippet.org/syntaxes', JSON.stringify(syntaxes))
+    fetchMock.getOnce('//api.xsnippet.org/v1/syntaxes', JSON.stringify(syntaxes))
 
     const store = createStore()
     await store.dispatch(actions.fetchSyntaxes)
@@ -274,7 +274,7 @@ describe('actions', () => {
       syntax: 'JavaScript',
     }
 
-    fetchMock.postOnce('//api.xsnippet.org/snippets', JSON.stringify(snippet))
+    fetchMock.postOnce('//api.xsnippet.org/v1/snippets', JSON.stringify(snippet))
 
     const store = createStore()
     await store.dispatch(actions.postSnippet(snippet, () => {}))


### PR DESCRIPTION
With new function urlFor we are able to pass different versions of api.
This approach lets us change api version for each request independently