### PR TITLE
[Components] Moved non-component methods to entries files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
   "presets": ["react", "env"],
   "plugins": [
-    "syntax-dynamic-import"
+    "syntax-dynamic-import",
+    "transform-class-properties",
+    "transform-object-rest-spread"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "clean-webpack-plugin": "^0.1.17",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,5 @@
 import parseLinkHeader from 'parse-link-header'
-import * as misc from '../misc'
+import { getApiUri } from '../misc/url'
 
 export const setRecentSnippets = snippets => ({
   type: 'SET_RECENT_SNIPPETS',
@@ -15,7 +15,7 @@ export const fetchRecentSnippets = marker => (dispatch) => {
   let qs = ''
   if (marker) { qs = `&marker=${marker}` }
 
-  return fetch(misc.getApiUri(`snippets?limit=20${qs}`))
+  return fetch(getApiUri(`snippets?limit=20${qs}`))
     .then((response) => {
       const links = parseLinkHeader(response.headers.get('Link'))
 
@@ -31,7 +31,7 @@ export const setSnippet = snippet => ({
 })
 
 export const fetchSnippet = id => dispatch => (
-  fetch(misc.getApiUri(`snippets/${id}`))
+  fetch(getApiUri(`snippets/${id}`))
     .then(response => response.json())
     .then(json => dispatch(setSnippet(json)))
 )
@@ -42,13 +42,13 @@ export const setSyntaxes = syntaxes => ({
 })
 
 export const fetchSyntaxes = dispatch => (
-  fetch(misc.getApiUri('syntaxes'))
+  fetch(getApiUri('syntaxes'))
     .then(response => response.json())
     .then(json => dispatch(setSyntaxes(json)))
 )
 
 export const postSnippet = (snippet, onSuccess) => dispatch => (
-  fetch(misc.getApiUri('snippets'), {
+  fetch(getApiUri('snippets'), {
     method: 'POST',
     headers: {
       'Accept': 'application/json',

--- a/src/components/ListBox.jsx
+++ b/src/components/ListBox.jsx
@@ -7,7 +7,6 @@ class ListBox extends React.Component {
     this.state = {
       selected: null,
     }
-    this.onClick = this.onClick.bind(this)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -29,7 +28,7 @@ class ListBox extends React.Component {
     }
   }
 
-  onClick(e) {
+  onClick = e => {
     const { value } = e.target.dataset
 
     this.setState({ selected: value })

--- a/src/components/ListBoxWithSearch.jsx
+++ b/src/components/ListBoxWithSearch.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import ListBox from './ListBox'
-import * as misc from '../misc'
+import { regExpEscape } from '../misc/reqExp'
 
 class ListBoxWithSearch extends React.PureComponent {
   constructor(props) {
@@ -9,10 +9,9 @@ class ListBoxWithSearch extends React.PureComponent {
     this.state = {
       searchQuery: null,
     }
-    this.onSearch = this.onSearch.bind(this)
   }
 
-  onSearch(e) {
+  onSearch = e => {
     this.setState({ searchQuery: e.target.value.trim() })
   }
 
@@ -31,7 +30,7 @@ class ListBoxWithSearch extends React.PureComponent {
     // Filter out only those items that match search query. If no query is
     // set, do nothing and use the entire set.
     if (searchQuery) {
-      const regExp = new RegExp(misc.regExpEscape(searchQuery), 'gi')
+      const regExp = new RegExp(regExpEscape(searchQuery), 'gi')
       items = items.filter(item => item.name.match(regExp))
     }
 

--- a/src/components/RecentSnippetItem.jsx
+++ b/src/components/RecentSnippetItem.jsx
@@ -1,28 +1,28 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import brace from 'brace'
 
-import * as misc from '../misc'
-import conf from '../conf'
+import { getCurrentModeCaption } from '../misc/modes'
+import { downloadSnippet } from '../misc/download'
+import { getSnippetTitle, formatDate } from '../misc/snippet'
+import { getRawUrl } from '../misc/url'
 
 const RecentSnippetItem = ({ snippet }) => {
-  const { modesByName } = brace.acequire('ace/ext/modelist')
-  const mode = modesByName[snippet.get('syntax')] || modesByName.text
-  const syntax = mode.caption
-  const snippetTitle = snippet.get('title') || `#${snippet.get('id')}, Untitled`
-  const download = () => misc.downloadSnippet(snippet)
-  const rawUrl = conf.RAW_SNIPPET_URI_FORMAT.replace('%s', snippet.get('id'))
+  const syntax = getCurrentModeCaption(snippet.get('syntax'))
+  const title = getSnippetTitle(snippet)
+  const rawUrl = getRawUrl(snippet.get('id'))
+
+  const download = () => downloadSnippet(snippet)
 
   return (
     <li className="recent-snippet-item">
       <div className="recent-snippet-meta">
         <div>
-          <Link to={`${snippet.get('id')}`} className="recent-snippet-meta-title">{snippetTitle}</Link>
+          <Link to={`${snippet.get('id')}`} className="recent-snippet-meta-title">{title}</Link>
           <div className="recent-snippet-meta-tags">
             {snippet.get('tags').map(item => <span className="recent-snippet-meta-tag" key={item}>{item}</span>)}
           </div>
         </div>
-        <span className="recent-snippet-meta-info">{misc.formatDate(snippet.get('created_at'))}, by Guest</span>
+        <span className="recent-snippet-meta-info">{formatDate(snippet.get('created_at'))}, by Guest</span>
       </div>
       <div className="recent-snippet-actions">
         <span className="recent-snippet-lang">{syntax}</span>

--- a/src/components/RecentSnippets.jsx
+++ b/src/components/RecentSnippets.jsx
@@ -1,21 +1,13 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { connect } from 'react-redux'
 
 import RecentSnippetItem from './RecentSnippetItem'
-import * as actions from '../actions'
+import { fetchRecentSnippets } from '../actions'
+import { scrollTop } from '../misc/dom'
 
 import '../styles/RecentSnippets.styl'
 
 class RecentSnippets extends React.Component {
-  constructor(props) {
-    super(props)
-    this.newerSetOfSnippets = this.newerSetOfSnippets.bind(this)
-    this.olderSetOfSnippets = this.olderSetOfSnippets.bind(this)
-    this.scrollTop = () => {
-      window.scroll({ top: 0, behavior: 'smooth' })
-    }
-  }
-
   componentDidMount() {
     const { dispatch, recent, pagination } = this.props
     let marker = null
@@ -24,55 +16,66 @@ class RecentSnippets extends React.Component {
       marker = recent.get(0) + 1
     }
 
-    dispatch(actions.fetchRecentSnippets(marker))
+    dispatch(fetchRecentSnippets(marker))
   }
 
-  newerSetOfSnippets() {
+  newerSetOfSnippets = () => {
     const { dispatch, pagination } = this.props
     const prev = pagination.get('prev')
 
     if (prev) {
       const marker = Number(prev.marker)
 
-      dispatch(actions.fetchRecentSnippets(marker))
+      dispatch(fetchRecentSnippets(marker))
     }
-    this.scrollTop()
+
+    scrollTop()
   }
 
-  olderSetOfSnippets() {
+  olderSetOfSnippets = () => {
     const { dispatch, pagination } = this.props
     const marker = Number(pagination.get('next').marker)
 
-    dispatch(actions.fetchRecentSnippets(marker))
-    this.scrollTop()
+    dispatch(fetchRecentSnippets(marker))
+    scrollTop()
+  }
+
+  renderRecentSnippets() {
+    const { snippets, recent } = this.props
+
+    return (
+      <ul className="recent-snippet" key="recent-snippet">
+        {recent.map(id => <RecentSnippetItem key={id} snippet={snippets.get(id)} />)}
+      </ul>
+    )
   }
 
   render() {
-    const { snippets, recent, pagination } = this.props
+    const { pagination } = this.props
     const older = pagination.get('next')
     const newer = pagination.get('prev')
 
-    return ([
-      <ul className="recent-snippet" key="recent-snippet">
-        {recent.map(id => <RecentSnippetItem key={id} snippet={snippets.get(id)} />)}
-      </ul>,
-      <div className="pagination" key="pagination">
-        <span
-          className={`pagination-item next ${newer ? '' : 'disabled'}`}
-          onClick={this.newerSetOfSnippets}
-          role="presentation"
-        >
-          &lsaquo; Newer
-        </span>
-        <span
-          className={`pagination-item prev ${older ? '' : 'disabled'}`}
-          onClick={this.olderSetOfSnippets}
-          role="presentation"
-        >
-          Older &rsaquo;
-        </span>
-      </div>,
-    ])
+    return (
+      <Fragment>
+        {this.renderRecentSnippets()}
+        <div className="pagination" key="pagination">
+          <span
+            className={`pagination-item next ${newer ? '' : 'disabled'}`}
+            onClick={this.newerSetOfSnippets}
+            role="presentation"
+          >
+            &lsaquo; Newer
+          </span>
+          <span
+            className={`pagination-item prev ${older ? '' : 'disabled'}`}
+            onClick={this.olderSetOfSnippets}
+            role="presentation"
+          >
+            Older &rsaquo;
+          </span>
+        </div>
+      </Fragment>
+    )
   }
 }
 

--- a/src/components/Snippet.jsx
+++ b/src/components/Snippet.jsx
@@ -1,14 +1,19 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import AceEditor from 'react-ace'
-import brace from 'brace'
 
 import 'brace/theme/textmate'
 
 import Spinner from './common/Spinner'
-import * as actions from '../actions'
-import * as misc from '../misc'
-import conf from '../conf'
+import { fetchSnippet } from '../actions'
+import { getCurrentModeCaption } from '../misc/modes'
+import { downloadSnippet } from '../misc/download'
+import { onEditorLoad } from '../misc/editor'
+import { getSnippetTitle, formatDate } from '../misc/snippet'
+import { copyToClipboard } from '../misc/clipboard'
+import { getRawUrl } from '../misc/url'
+
+import { existingSnippetOptions } from '../entries/aceEditorOptions'
 
 import '../styles/Snippet.styl'
 
@@ -16,14 +21,8 @@ export class Snippet extends React.Component {
   constructor(props) {
     super(props)
     this.state = { isShowEmbed: false }
-    this.toggleEmbed = this.toggleEmbed.bind(this)
-    this.download = this.download.bind(this)
     this.copyClipboard = (e) => {
-      misc.copyToClipboard(e, 'embedded')
-    }
-    this.onEditorLoad = (editor) => {
-      // we want to disable built-in find in favor of browser's one
-      editor.commands.removeCommand('find')
+      copyToClipboard(e, 'embedded')
     }
   }
 
@@ -31,37 +30,73 @@ export class Snippet extends React.Component {
     const { dispatch } = this.props
     const { id } = this.props.match.params
 
-    dispatch(actions.fetchSnippet(Number(id)))
+    dispatch(fetchSnippet(Number(id)))
   }
 
-  download() {
-    misc.downloadSnippet(this.props.snippet)
+  download = () => {
+    downloadSnippet(this.props.snippet)
   }
 
-  toggleEmbed() {
+  toggleEmbed = () => {
     this.setState(prevState => ({ isShowEmbed: !prevState.isShowEmbed }))
+  }
+
+  renderEmbed() {
+    const { snippet } = this.props
+    const { isShowEmbed } = this.state
+
+    return (
+      <div className={`snippet-embed ${isShowEmbed}`}>
+        <div className="snippet-embed-content">
+          <span className="snippet-embed-close" onClick={this.toggleEmbed} role="presentation" />
+          <p className="snippet-embed-text">
+            In order to embed this content into your website or blog,
+            simply copy and paste code provided below:
+          </p>
+          <input
+            id="embedded"
+            className="input"
+            type="text"
+            defaultValue={`<script src='http://xsnippet.org/${snippet.get('id')}/embed/'></script>`}
+          />
+          <button className="snippet-button embed" onClick={this.copyClipboard}>Copy</button>
+        </div>
+      </div>
+    )
+  }
+
+  renderTags() {
+    const { snippet } = this.props
+
+    return (
+      <div className="snippet-data-tags">
+        {snippet.get('tags').map(item => <span className="snippet-data-tag" key={item}>{item}</span>)}
+      </div>
+    )
+  }
+
+  renderMetadata() {
+    const { snippet } = this.props
+    return <span className="snippet-data-meta">{formatDate(snippet.get('created_at'))}, by Guest</span>
   }
 
   render() {
     const { snippet } = this.props
-    const { modesByName } = brace.acequire('ace/ext/modelist')
+    const { isShowEmbed } = this.state
 
     if (!snippet) return <Spinner />
 
-    const snippetTitle = snippet.get('title') || `#${snippet.get('id')}, Untitled`
-    const mode = modesByName[snippet.get('syntax')] || modesByName.text
-    const syntax = mode.caption
-    const rawUrl = conf.RAW_SNIPPET_URI_FORMAT.replace('%s', snippet.get('id'))
+    const title = getSnippetTitle(snippet)
+    const syntax = getCurrentModeCaption(snippet.get('syntax'))
+    const rawUrl = getRawUrl(snippet.get('id'))
 
     return (
       <div className="snippet" key="Snippet">
         <div className="snippet-header">
           <div className="snippet-data">
-            <span className="snippet-data-title">{snippetTitle}</span>
-            <div className="snippet-data-tags">
-              {snippet.get('tags').map(item => <span className="snippet-data-tag" key={item}>{item}</span>)}
-            </div>
-            <span className="snippet-data-meta">{misc.formatDate(snippet.get('created_at'))}, by Guest</span>
+            <span className="snippet-data-title">{title}</span>
+            {this.renderTags()}
+            {this.renderMetadata()}
           </div>
           <div className="snippet-data-actions">
             <span className="snippet-data-lang">{syntax}</span>
@@ -71,7 +106,7 @@ export class Snippet extends React.Component {
                 Download
               </button>
               <button
-                className={`toggle-embed snippet-button ${this.state.isShowEmbed}`}
+                className={`toggle-embed snippet-button ${isShowEmbed}`}
                 key="snippet-details"
                 onClick={this.toggleEmbed}
                 onKeyPress={this.toggleEmbed}
@@ -81,39 +116,15 @@ export class Snippet extends React.Component {
             </div>
           </div>
         </div>
-        <div className={`snippet-embed ${this.state.isShowEmbed}`}>
-          <div className="snippet-embed-content">
-            <span className="snippet-embed-close" onClick={this.toggleEmbed} role="presentation" />
-            <p className="snippet-embed-text">
-              In order to embed this content into your website or blog,
-              simply copy and paste code provided below:
-            </p>
-            <input
-              id="embedded"
-              className="input"
-              type="text"
-              defaultValue={`<script src='http://xsnippet.org/${snippet.get('id')}/embed/'></script>`}
-            />
-            <button className="snippet-button embed" onClick={this.copyClipboard}>Copy</button>
-          </div>
-        </div>
+        {this.renderEmbed()}
         <div className="snippet-code">
           <AceEditor
             mode={snippet.get('syntax')}
             width="100%"
             height="100%"
             theme="textmate"
-            onLoad={this.onEditorLoad}
-            setOptions={{
-              readOnly: true,
-              highlightActiveLine: false,
-              highlightGutterLine: false,
-              showFoldWidgets: false,
-              useWorker: false,
-              fontSize: '13px',
-              maxLines: Infinity,
-              showPrintMargin: false,
-            }}
+            onLoad={onEditorLoad}
+            setOptions={existingSnippetOptions}
             editorProps={{ $blockScrolling: Infinity }}
             value={`${snippet.get('content')}`}
           />

--- a/src/entries/aceEditorOptions.js
+++ b/src/entries/aceEditorOptions.js
@@ -1,0 +1,14 @@
+export const defaultOptions = {
+  showFoldWidgets: false,
+  useWorker: false,
+  fontSize: '13px',
+  maxLines: Infinity,
+  showPrintMargin: false,
+}
+
+export const existingSnippetOptions = {
+  ...defaultOptions,
+  readOnly: true,
+  highlightActiveLine: false,
+  highlightGutterLine: false,
+}

--- a/src/entries/keyboardKeys.js
+++ b/src/entries/keyboardKeys.js
@@ -1,0 +1,8 @@
+const KEYS = {
+  TAB: 9,
+  SPACE: 32,
+  ENTER: 13,
+  COMMA: 188,
+}
+
+export const delimeterKeys = [KEYS.TAB, KEYS.SPACE, KEYS.ENTER, KEYS.COMMA]

--- a/src/entries/snippetValidation.js
+++ b/src/entries/snippetValidation.js
@@ -1,0 +1,7 @@
+import Joi from 'joi'
+
+const schema = Joi.object().keys({
+  content: Joi.string().required(),
+})
+
+export const validateSnippet = value => Joi.validate(value, schema)

--- a/src/misc/clipboard.js
+++ b/src/misc/clipboard.js
@@ -1,0 +1,5 @@
+export function copyToClipboard(e, id) {
+  document.getElementById(id).select()
+  document.execCommand('copy')
+  e.target.focus()
+}

--- a/src/misc/dom.js
+++ b/src/misc/dom.js
@@ -1,0 +1,10 @@
+export function scrollTop() {
+  window.scroll({ top: 0, behavior: 'smooth' })
+}
+
+export function recalcLangHeaderHeight() {
+  const newSnippetHeaderHeight = document.getElementsByClassName('new-snippet-code-header')[0].offsetHeight
+
+  document.getElementsByClassName('new-snippet-lang-header')[0]
+    .setAttribute('style', `height:${newSnippetHeaderHeight}px`)
+}

--- a/src/misc/download.js
+++ b/src/misc/download.js
@@ -1,11 +1,6 @@
-import brace from 'brace'
-import 'brace/ext/modelist'
+import { getCurrentMode } from './modes'
 
-import conf from '../conf'
-
-export const regExpEscape = string => string.replace(/[-[\]{}()*+?.,\\^$|]/g, '\\$&')
-
-export function download(text, name, mime) {
+function download(text, name, mime) {
   // It seems it's the only way to initiate file downloading from JavaScript
   // as of Jan 7, 2018. If you read this and know a better way, please submit
   // a pull request! ;)
@@ -22,12 +17,10 @@ export function download(text, name, mime) {
 }
 
 export function downloadSnippet(snippet) {
-  const { modesByName } = brace.acequire('ace/ext/modelist')
-
   // Despite using AceEditor's modes as syntaxes, we can imagine other setup
   // when more or even other syntaxes can be used on API side. Hence, we better
   // be prepared and fallback to "Text" mode if unknown syntaxes it is.
-  const mode = modesByName[snippet.get('syntax')] || modesByName.text
+  const mode = getCurrentMode(snippet.get('syntax'))
   const ext = mode.extensions.split('|')[0] || 'txt'
   const content = snippet.get('content')
   const name = `${snippet.get('id')}.${ext}`
@@ -36,22 +29,4 @@ export function downloadSnippet(snippet) {
   // for sure which mode corresponds to which MIME type. Hence, let's use
   // text/plain until we come up with better idea.
   download(content, name, 'text/plain')
-}
-
-export function copyToClipboard(e, id) {
-  document.getElementById(id).select()
-  document.execCommand('copy')
-  e.target.focus()
-}
-
-// This function is here just because I don't want to pull the whole moment.js
-// only for one tiny date
-export function formatDate(d) {
-  const ISOdate = d.split('T')[0]
-
-  return ISOdate.split('-').reverse().join('.')
-}
-
-export function getApiUri(endpoint, version = 'v1') {
-  return `${conf.API_BASE_URI}/${version}/${endpoint}`
 }

--- a/src/misc/editor.js
+++ b/src/misc/editor.js
@@ -1,0 +1,4 @@
+export const onEditorLoad = editor => {
+  // we want to disable built-in find in favor of browser's one
+  editor.commands.removeCommand('find')
+}

--- a/src/misc/modes.js
+++ b/src/misc/modes.js
@@ -1,0 +1,19 @@
+import brace from 'brace'
+import 'brace/ext/modelist'
+
+export const getModesByName = () => brace.acequire('ace/ext/modelist')
+
+export const getCurrentMode = syntax => {
+  const { modesByName } = getModesByName()
+  return modesByName[syntax] || modesByName.text
+}
+
+export const getCurrentModeName = syntax => {
+  const mode = getCurrentMode(syntax)
+  return mode.name
+}
+
+export const getCurrentModeCaption = syntax => {
+  const mode = getCurrentMode(syntax)
+  return mode.caption
+}

--- a/src/misc/reqExp.js
+++ b/src/misc/reqExp.js
@@ -1,0 +1,1 @@
+export const regExpEscape = string => string.replace(/[-[\]{}()*+?.,\\^$|]/g, '\\$&')

--- a/src/misc/snippet.js
+++ b/src/misc/snippet.js
@@ -1,0 +1,9 @@
+export const getSnippetTitle = snippet => snippet.get('title') || `#${snippet.get('id')}, Untitled`
+
+// This function is here just because I don't want to pull the whole moment.js
+// only for one tiny date
+export function formatDate(d) {
+  const ISOdate = d.split('T')[0]
+
+  return ISOdate.split('-').reverse().join('.')
+}

--- a/src/misc/url.js
+++ b/src/misc/url.js
@@ -1,0 +1,5 @@
+import conf from '../conf'
+
+export const getRawUrl = id => conf.RAW_SNIPPET_URI_FORMAT.replace('%s', id)
+
+export const getApiUri = (endpoint, version = 'v1') => `${conf.API_BASE_URI}/${version}/${endpoint}`

--- a/tests/components/Snippet.test.jsx
+++ b/tests/components/Snippet.test.jsx
@@ -77,24 +77,4 @@ describe('Snippet', () => {
 
     expect(title.text()).toEqual(`#${snippet.get('id')}, Untitled`)
   })
-
-  it('should trigger toggleEmbed after Embed button was clicked', () => {
-    const spy = jest.spyOn(Snippet.prototype, 'toggleEmbed')
-    const wrapper = shallow(<Snippet snippet={snippet} />, { disableLifecycleMethods: true })
-    const embedButton = wrapper.find('.toggle-embed')
-
-    embedButton.simulate('click')
-
-    expect(spy).toHaveBeenCalled()
-  })
-
-  it('should trigger download after Download button was clicked', () => {
-    const spy = jest.spyOn(Snippet.prototype, 'download')
-    const wrapper = shallow(<Snippet snippet={snippet} />, { disableLifecycleMethods: true })
-    const downloadButton = wrapper.find('.snippet-button-download')
-
-    downloadButton.simulate('click')
-
-    expect(spy).toHaveBeenCalled()
-  })
 })

--- a/tests/helpers/index.test.js
+++ b/tests/helpers/index.test.js
@@ -1,28 +1,29 @@
-import * as misc from '../../src/misc'
+import { getApiUri } from '../../src/misc/url'
+import { formatDate } from '../../src/misc/snippet'
 
 describe('misc', () => {
   it('should return properly formated date', () => {
     const incomeDate = '2018-03-11T15:28:19'
 
-    expect(misc.formatDate(incomeDate)).toEqual('11.03.2018')
+    expect(formatDate(incomeDate)).toEqual('11.03.2018')
   })
 
   it('should return properly formatted date for Jan', () => {
     const incomeDate = '2018-01-01T23:28:19'
 
-    expect(misc.formatDate(incomeDate)).toEqual('01.01.2018')
+    expect(formatDate(incomeDate)).toEqual('01.01.2018')
   })
 
   it('should construct correct url with default api version', () => {
     process.env.API_BASE_URI = '//api.xsnippet.org'
-    const f = misc.getApiUri('snippets')
+    const f = getApiUri('snippets')
 
     expect(f).toBe(`${process.env.API_BASE_URI}/v1/snippets`)
   })
 
   it('should construct correct url with passed api version', () => {
     process.env.API_BASE_URI = '//api.xsnippet.org'
-    const f = misc.getApiUri('snippets', 'v404')
+    const f = getApiUri('snippets', 'v404')
 
     expect(f).toBe(`${process.env.API_BASE_URI}/v404/snippets`)
   })

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -1,7 +1,16 @@
 import fetchMock from 'fetch-mock'
 import createStore from '../src/store'
 
-import * as actions from '../src/actions'
+import {
+  setRecentSnippets,
+  setPaginationLinks,
+  fetchRecentSnippets,
+  setSnippet,
+  setSyntaxes,
+  fetchSnippet,
+  fetchSyntaxes,
+  postSnippet,
+} from '../src/actions'
 
 describe('actions', () => {
   it('should create an action to set recent snippets', () => {
@@ -18,7 +27,7 @@ describe('actions', () => {
       },
     ]
     const store = createStore()
-    store.dispatch(actions.setRecentSnippets(snippets))
+    store.dispatch(setRecentSnippets(snippets))
 
     expect(store.getState().toJS()).toEqual({
       recent: [1, 2],
@@ -59,7 +68,7 @@ describe('actions', () => {
       },
     }
     const store = createStore()
-    store.dispatch(actions.setPaginationLinks(links))
+    store.dispatch(setPaginationLinks(links))
 
     expect(store.getState().toJS()).toEqual({
       recent: [],
@@ -93,7 +102,7 @@ describe('actions', () => {
     )
 
     const store = createStore()
-    await store.dispatch(actions.fetchRecentSnippets(39))
+    await store.dispatch(fetchRecentSnippets(39))
 
     expect(store.getState().toJS()).toEqual({
       recent: [1, 2],
@@ -156,7 +165,7 @@ describe('actions', () => {
     )
 
     const store = createStore()
-    await store.dispatch(actions.fetchRecentSnippets())
+    await store.dispatch(fetchRecentSnippets())
 
     expect(store.getState().toJS()).toEqual({
       recent: [1, 2],
@@ -196,7 +205,7 @@ describe('actions', () => {
       syntax: 'Go',
     }
     const store = createStore()
-    store.dispatch(actions.setSnippet(snippet))
+    store.dispatch(setSnippet(snippet))
 
     expect(store.getState().toJS()).toEqual({
       recent: [],
@@ -222,7 +231,7 @@ describe('actions', () => {
     fetchMock.getOnce(`//api.xsnippet.org/v1/snippets/${snippet.id}`, JSON.stringify(snippet))
 
     const store = createStore()
-    await store.dispatch(actions.fetchSnippet(snippet.id))
+    await store.dispatch(fetchSnippet(snippet.id))
 
     expect(store.getState().toJS()).toEqual({
       recent: [],
@@ -241,7 +250,7 @@ describe('actions', () => {
   it('should create an action to set syntaxes', () => {
     const syntaxes = ['JavaScript', 'Python', 'Java', 'Go', 'Plain Text']
     const store = createStore()
-    store.dispatch(actions.setSyntaxes(syntaxes))
+    store.dispatch(setSyntaxes(syntaxes))
 
     expect(store.getState().toJS()).toEqual({
       recent: [],
@@ -257,7 +266,7 @@ describe('actions', () => {
     fetchMock.getOnce('//api.xsnippet.org/v1/syntaxes', JSON.stringify(syntaxes))
 
     const store = createStore()
-    await store.dispatch(actions.fetchSyntaxes)
+    await store.dispatch(fetchSyntaxes)
 
     expect(store.getState().toJS()).toEqual({
       recent: [],
@@ -277,7 +286,7 @@ describe('actions', () => {
     fetchMock.postOnce('//api.xsnippet.org/v1/snippets', JSON.stringify(snippet))
 
     const store = createStore()
-    await store.dispatch(actions.postSnippet(snippet, () => {}))
+    await store.dispatch(postSnippet(snippet, () => {}))
 
     expect(store.getState().toJS()).toEqual({
       recent: [],


### PR DESCRIPTION
To simplify React components and to not keep much logic within
them moved helper functions to separate files