### PR TITLE
[Assets] Remove width of team pictures on mobile

### DIFF
--- a/src/styles/AboutUs.styl
+++ b/src/styles/AboutUs.styl
@@ -76,7 +76,6 @@
         padding-bottom: 15px
         text-align: center
         & img
-          width: 200px
           & + div
             padding-left: 0
 


### PR DESCRIPTION
Removed `width` for pictures on mobile to prevent them from squeezing