### PR TITLE
[Tags] Fix NewSnippet header tags input

### DIFF
--- a/src/components/NewSnippet.jsx
+++ b/src/components/NewSnippet.jsx
@@ -37,23 +37,12 @@ const NewSnippet = ({ fetchSyntaxes, postSnippet, history, syntaxes }) => {
     fetchSyntaxes()
   }, [])
 
-  useEffect(() => {
-    recalcLangHeaderHeight()
-  }, [tags])
-
   function validate() {
     return validateSnippet({ content: content.trim() })
   }
 
   function post() {
     postSnippet({ content, title, tags: tags.map(tag => tag.text), syntax, cb: json => history.push(`/${json.id}`) })
-  }
-
-  const recalcLangHeaderHeight = () => {
-    const height = snippetHeader.current.offsetHeight
-
-    document.getElementsByClassName('new-snippet-lang-header')[0]
-      .setAttribute('style', `height:${height}px`)
   }
 
   const onTagBlur = tag => onTagAdded({ id: tag, text: tag })

--- a/src/styles/common/overwrite.styl
+++ b/src/styles/common/overwrite.styl
@@ -25,6 +25,8 @@
     width: 47%
     padding: 3px 5px 0
     min-height: 29px
+    height: 29px
+    overflow: scroll
     border-radius: 3px
     background-color: snippet-header-normal
   &__tag


### PR DESCRIPTION
Removed cross-component style changes (height of `ListBox` header were changed by `NewSnippet` component if too many tags were added) and replaced with optional scrollbar for tags input