### PR TITLE
Few improvements in GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: |
         npm install
         npm run build
-        tar cvzf bundle.tar.gz -C dist/ .
+        tar cvzf dist.tar.gz -C dist/ .
     - uses: actions/create-release@v1
       id: create_release
       env:
@@ -25,8 +25,9 @@ jobs:
     - uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GIT_TAG_NAME: ${GITHUB_REF#refs/*/}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./bundle.tar.gz
-        asset_name: xsnippet_web-${{ github.ref }}.tar.gz
+        asset_path: ./dist.tar.gz
+        asset_name: xsnippet-web-${GIT_TAG_NAME}.tar.gz
         asset_content_type: application/gzip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: |
         npm install
         npm run lint
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: |
         npm install
         npm run test
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: |
         npm install
         npm run build


### PR DESCRIPTION
1. Use `setup-node@v2` instead of `setup-node@v1`. We don't use any
   specific, but let's stick with newer version assuming it's there
   for a greater good.

2. Fix name of the uploaded release bundle. Apparently,
   `${{ github.ref }}` is a fully qualified tag name in the form of
   `refs/tags/<tag-name>`. Since we're interested in the `<tag-name>`,
   we need to do a trick to extract the value from it.