### PR TITLE
Add docker-compose.yml for launching devenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ The source code is distributed under MIT license. Feel free to contribute by
 any means. Your feedback is welcome as well!
 
 
+Develompent
+-----------
+
+By default, the source code points to a production instance of XSnippet API.
+In order to avoid spamming production database, one can easily setup a local
+devenv using `docker-compose`, e.g.
+
+```bash
+$ npm run devenv-up
+```
+
+and starting XSnippet Web configured to use this local version, e.g.
+
+```bash
+$ npm run devenv-start
+```
+
+
 Links
 -----
 

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  xsnippet-api:
+    image: xsnippet/xsnippet-api:v1.1.0
+    environment:
+      - XSNIPPET_SERVER_HOST=0.0.0.0
+      - XSNIPPET_SERVER_PORT=8000
+      - XSNIPPET_DATABASE_CONNECTION_URI=mongodb://database:27017/xsnippet
+      - XSNIPPET_SNIPPET_SYNTAXES=rust,python,javascript,markdown,json,d,css,html
+    ports:
+      - 8000:8000
+    depends_on:
+      - database
+  xsnippet-web-backend:
+    image: xsnippet/xsnippet-web-backend:v1.0.0
+    environment:
+      - XSNIPPET_WEB_PROXY_HOST=0.0.0.0
+      - XSNIPPET_WEB_PROXY_PORT=8000
+      - XSNIPPET_API_URL=http://xsnippet-api:8000
+    ports:
+      - 8001:8000
+    depends_on:
+      - xsnippet-api
+  database:
+    image: mongo:3

--- a/package.json
+++ b/package.json
@@ -90,7 +90,9 @@
     "lint": "eslint --ignore-path .gitignore --ext js,jsx .",
     "build": "webpack --mode production",
     "start": "webpack-dev-server --mode development --open",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "devenv-start": "API_BASE_URI=\"http://localhost:8080/_api\" RAW_SNIPPET_URI_FORMAT=\"http://localhost:8080/_web-backend/snippets/%s/raw\" npm start",
+    "devenv-up": "docker-compose -f devenv/docker-compose.yml up"
   },
   "private": true
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,17 @@ module.exports = () => {
 
     devServer: {
       historyApiFallback: true,
+      proxy: {
+        '/_api': {
+          target: 'http://localhost:8000',
+          pathRewrite: { '^/_api': '' },
+          headers: { Host: 'localhost:8000/_api' },
+        },
+        '/_web-backend': {
+          target: 'http://localhost:8001',
+          pathRewrite: { '^/_web-backend': '' },
+        },
+      },
     },
 
     entry: {


### PR DESCRIPTION
In order to avoid spamming production database with garbage snippets, one should probably use local devenv for this purpose. This patch adds a `docker-compose.yml` that can help to spin up a devenv with XSnippet API inside.

For convenience, the invokation command is hidden behind `npm run xsnippet-api-devenv` alias.