### PR TITLE
Fix Snippet route

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -49,7 +49,7 @@ const App = () => {
           <main className="main">
             <Route exact path="/" component={NewSnippet} />
             <Route exact path="/recent" component={RecentSnippets} />
-            <Route exact path="/:id(\d+)" component={Snippet} />
+            <Route exact path="/:id([a-zA-Z0-9]+)" component={Snippet} />
             <Route exact path="/about" component={About} />
             <Route exact path="/sign-in" component={SignIn} />
           </main>


### PR DESCRIPTION
The new version of xsnippet-api uses alphanumeric slugs instead of integer identifiers, so we need to update the regex accordingly to work with all possible snippet id values.